### PR TITLE
add fix for inactive channel bug

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/PoolConfiguration.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/PoolConfiguration.kt
@@ -12,6 +12,7 @@ package com.github.jasync.sql.db.pool
  * @param validationInterval pools will use this value as the timer period to validate idle objects.
  * @param createTimeout the timeout for connecting to servers
  * @param testTimeout the timeout for connection tests performed by pools
+ * @param queryTimeout the optional query timeout
  */
 
 data class PoolConfiguration @JvmOverloads constructor(
@@ -20,7 +21,8 @@ data class PoolConfiguration @JvmOverloads constructor(
     val maxQueueSize: Int,
     val validationInterval: Long = 5000,
     val createTimeout: Long = 5000,
-    val testTimeout: Long = 5000
+    val testTimeout: Long = 5000,
+    val queryTimeout: Long? = null
     )
 {
   companion object {

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/TimeoutScheduler.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/TimeoutScheduler.kt
@@ -73,7 +73,7 @@ open class TimeoutSchedulerPartialImpl(private val executor: Executor) : Timeout
             }
           },
           duration)
-      promise.onCompleteAsync(executor) { _ -> scheduledFuture.cancel(false) }
+      promise.onCompleteAsync(executor) { scheduledFuture.cancel(false) }
       scheduledFuture
     }
   }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -172,6 +172,19 @@ class ActorBasedObjectPoolTest {
   }
 
   @Test
+  fun `on query timeout pool should destroy item`() {
+    tested = ActorBasedObjectPool(factory, configuration.copy(
+            queryTimeout = 10
+    ), false)
+    val widget = tested.take().get()
+    Thread.sleep(20)
+    tested.testAvailableItems()
+    await.untilCallTo { factory.destroyed } matches { it == listOf(widget) }
+    assertThat(tested.availableItems).isEmpty()
+    assertThat(tested.usedItems).isEmpty()
+  }
+
+  @Test
   fun `when queue is bigger then max waiting, future should fail`() {
     tested = ActorBasedObjectPool(factory, configuration.copy(
         maxObjects = 1,

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
@@ -103,10 +103,10 @@ class MySQLConnection @JvmOverloads constructor(
   }
 
   fun close(): CompletableFuture<Connection> {
+    val exception = DatabaseException("Connection is being closed")
+    this.failQueryPromise(exception)
     if (this.isConnected()) {
       if (!this.disconnectionPromise.isCompleted) {
-        val exception = DatabaseException("Connection is being closed")
-        this.failQueryPromise(exception)
         this.connectionHandler.clearQueryState()
         this.connectionHandler.write(QuitMessage.Instance).toCompletableFuture().onCompleteAsync(executionContext) { ty1 ->
           when (ty1) {


### PR DESCRIPTION
Found that in mysql proxy sometimes immediately after query is sent
there is a channel inactive message and no more messages
Even timeout on connection is not working because of a check if connection is active in disconenct method

Add 2 fixes:
- In case of timeout, fail the query future even if not connected
It happens only once anyway
- Add a query timeout parameter to the pool, which is observing all items from outside anyway