### PR TITLE
issue #59 - add 30 sec to timeout before cleaning up the object from …

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/PoolConfiguration.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/PoolConfiguration.kt
@@ -24,6 +24,7 @@ data class PoolConfiguration @JvmOverloads constructor(
     val queryTimeout: Long? = null
 ) {
     companion object {
-        val Default = PoolConfiguration(10, 4, 10)
+        @Suppress("unused")
+        val Default = PoolConfiguration(30, 10, 100000)
     }
 }

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/TimeoutScheduler.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/TimeoutScheduler.kt
@@ -44,7 +44,7 @@ class TimeoutSchedulerImpl(
 
     override fun isTimeout(): Boolean = isTimeoutBool.get()
 
-    fun schedule(block: () -> Unit, duration: Duration): ScheduledFuture<*> {
+    private fun schedule(block: () -> Unit, duration: Duration): ScheduledFuture<*> {
         return eventLoopGroup.schedule({
             block()
         }, duration.toMillis(), TimeUnit.MILLISECONDS)

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/AbstractAsyncObjectPoolSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/AbstractAsyncObjectPoolSpec.kt
@@ -29,7 +29,7 @@ abstract class AbstractAsyncObjectPoolSpec<T : AsyncObjectPool<Widget>> {
 
     protected abstract fun pool(
         factory: ObjectFactory<Widget> = TestWidgetFactory(),
-        conf: PoolConfiguration = PoolConfiguration.Default
+        conf: PoolConfiguration = PoolConfiguration(10, 4, 10)
     ): T
 
     @Test
@@ -111,7 +111,7 @@ abstract class AbstractAsyncObjectPoolSpec<T : AsyncObjectPool<Widget>> {
 
     @Test
     fun `queue requests after running out`() {
-        val p = pool(conf = PoolConfiguration.Default.copy(maxObjects = 2, maxQueueSize = 1))
+        val p = pool(conf = PoolConfiguration(maxIdle = 4, maxObjects = 2, maxQueueSize = 1))
         val widgets = (1..2).map { p.take().get() }
         val future = p.take()
 
@@ -169,7 +169,7 @@ abstract class AbstractAsyncObjectPoolSpec<T : AsyncObjectPool<Widget>> {
         // Deliberately make it impossible to expire (nearly)
         val p = pool(
             factory = factory,
-            conf = PoolConfiguration.Default.copy(maxIdle = Long.MAX_VALUE, validationInterval = 2000)
+            conf = PoolConfiguration(maxObjects = 10, maxIdle = Long.MAX_VALUE, maxQueueSize = 10, validationInterval = 2000)
         )
         val widget = p.take().get()
         assertThat(widget).isNotNull

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.ExecutionException
 class ActorBasedObjectPoolTest {
 
     private val factory = ForTestingMyFactory()
-    private val configuration = PoolConfiguration.Default.copy(
+    private val configuration = PoolConfiguration(
         maxObjects = 10, maxQueueSize = Int.MAX_VALUE,
         validationInterval = Long.MAX_VALUE, maxIdle = Long.MAX_VALUE
     )
@@ -187,7 +187,8 @@ class ActorBasedObjectPoolTest {
         tested = ActorBasedObjectPool(
             factory, configuration.copy(
                 queryTimeout = 10
-            ), false
+            ), false,
+            extraTimeForTimeoutCompletion = 1
         )
         val widget = tested.take().get()
         Thread.sleep(20)
@@ -229,8 +230,7 @@ class ActorBasedObjectPoolTest {
     }
 
     private fun takeLostItem() {
-        var widget: ForTestingMyWidget? = tested.take().get()
-        widget = null
+        tested.take().get()
     }
 
 }

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionHelper.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionHelper.kt
@@ -100,7 +100,7 @@ open class ConnectionHelper : ContainerHelper() {
     fun <T> withConfigurablePool(configuration: Configuration, f: (ConnectionPool<MySQLConnection>) -> T): T {
 
         val factory = MySQLConnectionFactory(configuration)
-        val pool = ConnectionPool(factory, PoolConfiguration.Default)
+        val pool = ConnectionPool(factory, PoolConfiguration(10, 4, 10))
 
         try {
             return f(pool)

--- a/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnection.kt
+++ b/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnection.kt
@@ -123,6 +123,7 @@ class PostgreSQLConnection @JvmOverloads constructor(
 
     override fun isTimeout(): Boolean = timeoutSchedulerImpl.isTimeout()
 
+    @Suppress("unused")
     fun parameterStatuses(): Map<String, String> = this.parameterStatus.toMap()
 
     override fun sendQuery(query: String): CompletableFuture<QueryResult> {

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/ConnectionPoolSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/ConnectionPoolSpec.kt
@@ -75,7 +75,7 @@ class ConnectionPoolSpec : DatabaseTestHelper() {
 
     private fun <R> withPool(fn: (ConnectionPool<PostgreSQLConnection>) -> R): R {
 
-        val pool = ConnectionPool(PostgreSQLConnectionFactory(defaultConfiguration), PoolConfiguration.Default)
+        val pool = ConnectionPool(PostgreSQLConnectionFactory(defaultConfiguration), PoolConfiguration(10, 4, 10))
         try {
             return fn(pool)
         } finally {

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/NextGenConnectionPoolSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/NextGenConnectionPoolSpec.kt
@@ -76,7 +76,7 @@ class NextGenConnectionPoolSpec : DatabaseTestHelper() {
 
 fun <R> withPoolNG(fn: (ConnectionPool<PostgreSQLConnection>) -> R): R {
 
-    val pool = ConnectionPool(PostgreSQLConnectionFactory(defaultConfiguration), PoolConfiguration.Default)
+    val pool = ConnectionPool(PostgreSQLConnectionFactory(defaultConfiguration), PoolConfiguration(10, 4, 10))
     try {
         return fn(pool)
     } finally {


### PR DESCRIPTION
…the pool

this will allow normal scheduler to trigger timeout and handle timeout before which is the preferred way
because less errors are getting to the logs