### PR TITLE
A mini PR, to simplify lazy loading of `execute`

### DIFF
--- a/r2dbc-mysql/src/main/java/SimpleStatement.kt
+++ b/r2dbc-mysql/src/main/java/SimpleStatement.kt
@@ -46,9 +46,7 @@ class SimpleStatement(private val clientSupplier: Supplier<JasyncConnection>, pr
     }
 
     override fun execute(): Publisher<out Result> {
-        val jasyncConnection = clientSupplier.get()
-
-        return Mono.defer({
+        return Mono.fromSupplier(clientSupplier).flatMap { jasyncConnection ->
             val r = if (isPrepared) {
                 val preparedParams = mutableListOf<Any?>()
                 for (i in 0 until params.size) {
@@ -63,6 +61,6 @@ class SimpleStatement(private val clientSupplier: Supplier<JasyncConnection>, pr
                 jasyncConnection.sendQuery(this.sql)
             }
             r.toMono().map { JaysncResult(it.rows, it.rowsAffected) }
-        })
+        }
     }
 }


### PR DESCRIPTION
This may reduce the creation of temporary objects (which of course has little effect), but this seems to be more in line with the *philosophy* of the Reactor.