### PR TITLE
fix an issue of timeout in connection creation, even if timeout did not pass

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ActorBasedObjectPool.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ActorBasedObjectPool.kt
@@ -311,11 +311,12 @@ private class ObjectPoolActor<T : PooledObject>(
 
     private fun checkItemsInCreationForTimeout() {
         inCreateItems.entries.removeAll {
-            if (it.value.timeElapsed > configuration.createTimeout) {
+            val timeout = it.value.timeElapsed > configuration.createTimeout
+            if (timeout) {
                 logger.trace { "failed to create item ${it.key} after ${it.value.timeElapsed} ms" }
+                it.value.item.completeExceptionally(TimeoutException("failed to create item ${it.key} after ${it.value.timeElapsed} ms"))
             }
-            it.value.item.completeExceptionally(TimeoutException("failed to create item ${it.key} after ${it.value.timeElapsed} ms"))
-            it.value.timeElapsed > configuration.createTimeout
+            timeout
         }
     }
 

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/util/FutureUtils.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/util/FutureUtils.kt
@@ -84,8 +84,8 @@ inline fun <A> CompletableFuture<A>.onCompleteAsync(
     whenCompleteAsync(BiConsumer { a, t -> onCompleteFun(if (t != null) Try.raise(t) else Try.just(a)) }, executor)
 
 val <A> CompletableFuture<A>.isCompleted get() = this.isDone
-val <A> CompletableFuture<A>.isSuccess: Boolean get() = this.isDone && this.isCompleted
-val <A> CompletableFuture<A>.isFailure: Boolean get() = this.isDone && this.isCompletedExceptionally
+val <A> CompletableFuture<A>.isSuccess: Boolean get() = this.isDone && !this.isCompletedExceptionally && !this.isCancelled
+val <A> CompletableFuture<A>.isFailure: Boolean get() = this.isDone && (this.isCompletedExceptionally || this.isCancelled)
 
 
 fun <A> CompletableFuture<A>.complete(t: Try<A>) = when (t) {

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -2,6 +2,7 @@ package com.github.jasync.sql.db.pool
 
 import com.github.jasync.sql.db.util.FP
 import com.github.jasync.sql.db.util.Try
+import com.github.jasync.sql.db.util.isSuccess
 import com.github.jasync.sql.db.verifyException
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -50,6 +51,20 @@ class ActorBasedObjectPoolTest {
         Thread.sleep(20)
         tested.testAvailableItems()
         await.untilCallTo { result.isCompletedExceptionally } matches { it == true }
+    }
+
+    @Test
+    fun `basic take operation - when create is little stuck should not be timeout (create timeout is 5 sec)`() {
+        tested = ActorBasedObjectPool(
+            factory, configuration.copy(
+                createTimeout = 5000
+            ), false
+        )
+        factory.creationStuckTime = 10
+        val result = tested.take()
+        Thread.sleep(20)
+        tested.testAvailableItems()
+        await.untilCallTo { result.isSuccess } matches { it == true }
     }
 
     @Test
@@ -290,6 +305,7 @@ class ForTestingMyFactory : ObjectFactory<ForTestingMyWidget> {
     val validated = mutableListOf<ForTestingMyWidget>()
     val tested = mutableMapOf<ForTestingMyWidget, CompletableFuture<ForTestingMyWidget>>()
     var creationStuck: Boolean = false
+    var creationStuckTime: Long? = null
     var failCreation: Boolean = false
     var failCreationFuture: Boolean = false
     var failValidation: Boolean = false
@@ -298,6 +314,16 @@ class ForTestingMyFactory : ObjectFactory<ForTestingMyWidget> {
     override fun create(): CompletableFuture<ForTestingMyWidget> {
         if (creationStuck) {
             return CompletableFuture()
+        }
+        if (creationStuckTime != null) {
+            val f = CompletableFuture<ForTestingMyWidget>()
+            Thread{
+                Thread.sleep(creationStuckTime!!)
+                val widget = ForTestingMyWidget()
+                created += widget
+                f.complete(widget)
+            }.start()
+            return f
         }
         if (failCreation) {
             throw Exception("failed to create")


### PR DESCRIPTION
here is a stacktrace:
```
java.util.concurrent.TimeoutException: failed to create item 165 after 2 ms
        at com.github.jasync.sql.db.pool.ObjectPoolActor$checkItemsInCreationForTimeout$1.invoke(ActorBasedObjectPool.kt:317)
        at com.github.jasync.sql.db.pool.ObjectPoolActor$checkItemsInCreationForTimeout$1.invoke(ActorBasedObjectPool.kt:197)
        at kotlin.collections.CollectionsKt__MutableCollectionsKt.filterInPlace$CollectionsKt__MutableCollectionsKt(MutableCollections.kt:166)
        at kotlin.collections.CollectionsKt__MutableCollectionsKt.removeAll(MutableCollections.kt:155)
        at com.github.jasync.sql.db.pool.ObjectPoolActor.checkItemsInCreationForTimeout(ActorBasedObjectPool.kt:313)
        at com.github.jasync.sql.db.pool.ObjectPoolActor.handleTestAvailableItems(ActorBasedObjectPool.kt:283)
        at com.github.jasync.sql.db.pool.ObjectPoolActor.onReceive(ActorBasedObjectPool.kt:226)
        at com.github.jasync.sql.db.pool.ActorBasedObjectPool$actor$1.invokeSuspend(ActorBasedObjectPool.kt:141)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
        at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:233)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:742)
```