### PR TITLE
change the default utf8 encoding

### DIFF
--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/util/CharsetMapper.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/util/CharsetMapper.kt
@@ -11,7 +11,7 @@ class CharsetMapper(charsetsToIntComplement: Map<Charset, Int> = emptyMap()) {
         const val Binary = 63
 
         val DefaultCharsetsByCharset = mapOf(
-            CharsetUtil.UTF_8 to 83,
+            CharsetUtil.UTF_8 to Integer.getInteger("jasyncMysqlUTF8Collation", 224), //previous default was 83
             CharsetUtil.US_ASCII to 65,
             CharsetUtil.ISO_8859_1 to 69
         )

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QuerySpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QuerySpec.kt
@@ -56,6 +56,24 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
+    fun `test insert and query with unicode emoji`() {
+        val createTableEmoji = """CREATE TEMPORARY TABLE users (
+                              id INT NOT NULL AUTO_INCREMENT ,
+                              name VARCHAR(255) CHARACTER SET 'utf8mb4' NOT NULL ,
+                              PRIMARY KEY (id) );"""
+        val insertEmoji = """INSERT INTO users (name) VALUES ('Boogie Man💩')"""
+        withConnection { connection ->
+            assertThat(executeQuery(connection, createTableEmoji).rowsAffected).isEqualTo(0)
+            assertThat(executeQuery(connection, insertEmoji).rowsAffected).isEqualTo(1)
+            val result: ResultSet = executeQuery(connection, this.select).rows
+
+            assertThat(result[0]("id")).isEqualTo(1)
+            assertThat(result(0)("name")).isEqualTo("""Boogie Man💩""")
+        }
+
+    }
+
+    @Test
     fun `"connection" should   "be able to select from a table" - validate columnNames()`() {
 
         withConnection { connection ->


### PR DESCRIPTION
according to this post https://mathiasbynens.be/notes/mysql-utf8mb4
the default utf8 in mysql do not exactly match utf8 standard (3 vs 4 bytes)

Since it maps to the same charset in Java
It sounds like the reasonable thing to do is to change the used protocol
from 83 to 224 (utf8mb4_unicode_ci)
I added a flag to allow overriding it `-DjasyncMysqlUTF8Collation=83`
To put in back in the old legacy behaviour
for example if using mysql server < 5.5.3.

Added also tests for this.

This PR, is a fix for the issue raised here: https://github.com/vert-x3/vertx-mysql-postgresql-client/issues/149