### PR TITLE
prevent ConnectionFactory.test from throwing an exception, instead return failed future

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ConnectionFactory.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ConnectionFactory.kt
@@ -4,6 +4,7 @@ import com.github.jasync.sql.db.ConcreteConnection
 import com.github.jasync.sql.db.exceptions.ConnectionNotConnectedException
 import com.github.jasync.sql.db.exceptions.ConnectionStillRunningQueryException
 import com.github.jasync.sql.db.exceptions.ConnectionTimeoutedException
+import com.github.jasync.sql.db.util.FP
 import com.github.jasync.sql.db.util.Try
 import com.github.jasync.sql.db.util.map
 import mu.KotlinLogging
@@ -77,10 +78,14 @@ abstract class ConnectionFactory<T: ConcreteConnection>: ObjectFactory<T> {
      * @return
      */
     override fun test(item: T): CompletableFuture<T> {
-        return if (testCounter++.rem(2) == 0) {
+        return try {
+            if (testCounter++.rem(2) == 0) {
                 item.sendPreparedStatement("SELECT 0", emptyList(), true).map { item }
             } else {
                 item.sendQuery("SELECT 0").map { item }
             }
+        } catch (e: Exception) {
+            FP.failed(e)
+        }
     }
 }

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/pool/MySQLConnectionFactorySpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/pool/MySQLConnectionFactorySpec.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class MySQLConnectionFactorySpec : ConnectionHelper() {
-    val factory = MySQLConnectionFactory(getConfiguration())
+    private val factory = MySQLConnectionFactory(getConfiguration())
 
     @Test
     fun `fail validation if a connection has errored`() {
@@ -78,21 +78,26 @@ class MySQLConnectionFactorySpec : ConnectionHelper() {
         assertEquals(connection, awaitFuture(connection.close()))
     }
 
+    @Test
     fun `accept a good connection`() {
         val connection = factory.create().get()
         assertFalse(factory.validate(connection).isFailure)
         assertEquals(connection, awaitFuture(connection.close()))
     }
 
+    @Test
     fun `test a valid connection and say it is ok`() {
 
         val connection = factory.create().get()
 
-        assertTrue(factory.test(connection).isSuccess)
+        val future = factory.test(connection)
+        awaitFuture(future)
+        assertTrue(future.isSuccess)
         assertEquals(connection, awaitFuture(connection.close()))
 
     }
 
+    @Test
     fun `fail test if a connection is disconnected`() {
         val connection = factory.create().get()
 


### PR DESCRIPTION
This will prevent exception from propogating to the object pool.

Had exceptions like this in the log:

```
java.lang.IllegalStateException: not connected so can’t execute queries. please make sure connect() was called and disconnect() was not called.(not connected so can’t execute queries. please make sure connect() was called and disconnect() was not called.)
 at com.github.jasync.sql.db.mysql.MySQLConnection.validateIsReadyForQuery(MySQLConnection.kt:314)
 at com.github.jasync.sql.db.mysql.MySQLConnection.sendQueryDirect(MySQLConnection.kt:238)
 at com.github.jasync.sql.db.ConcreteConnectionBase$sendQuery$1.invoke(ConcreteConnectionBase.kt:58)
 at com.github.jasync.sql.db.ConcreteConnectionBase$sendQuery$1.invoke(ConcreteConnectionBase.kt:16)
 at com.github.jasync.sql.db.interceptor.ConnectionInterceptorHelperKt.wrapQueryWithInterceptors(ConnectionInterceptorHelper.kt:13)
 at com.github.jasync.sql.db.ConcreteConnectionBase.sendQuery(ConcreteConnectionBase.kt:57)
 at com.github.jasync.sql.db.pool.ConnectionFactory.test(ConnectionFactory.kt:83)
 at com.github.jasync.sql.db.pool.ConnectionFactory.test(ConnectionFactory.kt:14)
 at com.github.jasync.sql.db.pool.ObjectPoolActor.sendAvailableItemsToTest(ActorBasedObjectPool.kt:342)
 at com.github.jasync.sql.db.pool.ObjectPoolActor.handleTestAvailableItems(ActorBasedObjectPool.kt:282)
 at com.github.jasync.sql.db.pool.ObjectPoolActor.onReceive(ActorBasedObjectPool.kt:226)
 at com.github.jasync.sql.db.pool.ActorBasedObjectPool$actor$1.invokeSuspend(ActorBasedObjectPool.kt:141)
 at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
 at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:233)
 at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594)
 at kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:742)
```