### PR TITLE
Add scalikejdbc-async to the list of users on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can view the project's change log [here](CHANGELOG.md).
 * https://github.com/humb1t/jpom
 * [Zeko Data Mapper](https://github.com/darkredz/Zeko-Data-Mapper)
 * [vertx-jooq async module](https://github.com/jklingsporn/vertx-jooq)
+* [ScalikeJDBC Async](https://github.com/scalikejdbc/scalikejdbc-async)
 
 Add your name here!
 


### PR DESCRIPTION
Thanks for making a great successor of postgresql/mysql-async. We've switched to this library. Could you have us as one of the users on README?

https://github.com/scalikejdbc/scalikejdbc-async/pull/74