### PR TITLE
Allow more type for `JasyncInsertSyntheticRow`

### DIFF
--- a/r2dbc-mysql/src/main/java/JasyncInsertSyntheticMetadata.kt
+++ b/r2dbc-mysql/src/main/java/JasyncInsertSyntheticMetadata.kt
@@ -18,23 +18,9 @@ internal class JasyncInsertSyntheticMetadata(private val generatedKeyName: Strin
     }
 
     override fun getColumnMetadata(identifier: Any): ColumnMetadata {
-        return when (identifier) {
-            is Int -> {
-                when {
-                    identifier > 0 -> throw ArrayIndexOutOfBoundsException("Column index $identifier is larger than the number of columns 1")
-                    identifier < 0 -> throw ArrayIndexOutOfBoundsException("Column index $identifier is negative")
-                    else -> this
-                }
-            }
-            is String -> {
-                if (generatedKeyName.equals(identifier, true)) {
-                    throw NoSuchElementException("Column name '$identifier' does not exist in column names [$generatedKeyName]")
-                }
+        assertValidIdentifier(identifier)
 
-                this
-            }
-            else -> throw IllegalArgumentException("Identifier '$identifier' is not a valid identifier. Should either be an Integer index or a String column name.")
-        }
+        return this
     }
 
     override fun getColumnNames(): Collection<String> {
@@ -43,5 +29,22 @@ internal class JasyncInsertSyntheticMetadata(private val generatedKeyName: Strin
 
     override fun getName(): String {
         return generatedKeyName
+    }
+
+    private fun assertValidIdentifier(identifier: Any) {
+        when (identifier) {
+            is Int -> {
+                when {
+                    identifier > 0 -> throw ArrayIndexOutOfBoundsException("Column index $identifier is larger than the number of columns 1")
+                    identifier < 0 -> throw ArrayIndexOutOfBoundsException("Column index $identifier is negative")
+                }
+            }
+            is String -> {
+                if (!generatedKeyName.equals(identifier, true)) {
+                    throw NoSuchElementException("Column name '$identifier' does not exist in column names [$generatedKeyName]")
+                }
+            }
+            else -> throw IllegalArgumentException("Identifier '$identifier' is not a valid identifier. Should either be an Integer index or a String column name.")
+        }
     }
 }

--- a/r2dbc-mysql/src/test/java/JasyncInsertSyntheticMetadataTest.kt
+++ b/r2dbc-mysql/src/test/java/JasyncInsertSyntheticMetadataTest.kt
@@ -1,0 +1,53 @@
+package com.github.jasync.r2dbc.mysql
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [JasyncInsertSyntheticMetadata].
+ */
+class JasyncInsertSyntheticMetadataTest {
+
+    private val metadata1 = JasyncInsertSyntheticMetadata("SomeId")
+
+    private val metadata2 = JasyncInsertSyntheticMetadata("GoodsId")
+
+    @Test
+    fun getColumnMetadatas() {
+        assertEquals(metadata1.columnMetadatas, listOf(metadata1))
+        assertEquals(metadata2.columnMetadatas, listOf(metadata2))
+    }
+
+    @Test
+    fun getColumnMetadata() {
+        assertEquals(metadata1.getColumnMetadata(0), metadata1)
+        assertEquals(metadata1.getColumnMetadata("SomeId"), metadata1)
+        assertEquals(metadata1.getColumnMetadata("someId"), metadata1)
+        assertEquals(metadata1.getColumnMetadata("SOMEID"), metadata1)
+
+        assertEquals(metadata2.getColumnMetadata(0), metadata2)
+        assertEquals(metadata2.getColumnMetadata("GoodsId"), metadata2)
+        assertEquals(metadata2.getColumnMetadata("goodsId"), metadata2)
+        assertEquals(metadata2.getColumnMetadata("GOODSID"), metadata2)
+    }
+
+    @Test
+    fun getColumnNames() {
+        assertEquals(metadata1.columnNames, setOf("SomeId"))
+        assertEquals(metadata2.columnNames, setOf("GoodsId"))
+
+        assertTrue("SomeId" in metadata1.columnNames)
+        assertTrue("someId" in metadata1.columnNames)
+        assertTrue("SOMEID" in metadata1.columnNames)
+        assertTrue("GoodsId" in metadata2.columnNames)
+        assertTrue("goodsId" in metadata2.columnNames)
+        assertTrue("GOODSID" in metadata2.columnNames)
+    }
+
+    @Test
+    fun getName() {
+        assertEquals(metadata1.name, "SomeId")
+        assertEquals(metadata2.name, "GoodsId")
+    }
+}

--- a/r2dbc-mysql/src/test/java/JasyncInsertSyntheticRowTest.kt
+++ b/r2dbc-mysql/src/test/java/JasyncInsertSyntheticRowTest.kt
@@ -1,0 +1,40 @@
+package com.github.jasync.r2dbc.mysql
+
+import org.junit.Test
+import java.math.BigInteger
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for [JasyncInsertSyntheticRow].
+ */
+internal class JasyncInsertSyntheticRowTest {
+
+    @Test
+    @ExperimentalUnsignedTypes
+    fun get() {
+        val positive = JasyncInsertSyntheticRow("SomeId", 1)
+        val overflowed = JasyncInsertSyntheticRow("GoodsId", ULong.MAX_VALUE.toLong())
+
+        assertEquals(positive["SomeId"]?.javaClass as Class<*>?, java.lang.Long::class.java)
+        assertEquals(positive["SomeId", Any::class.java]?.javaClass as Class<*>?, java.lang.Long::class.java)
+        assertEquals(positive["SomeId"], 1L)
+        assertEquals(positive["someId"], 1L)
+        assertEquals(positive["SOMEID"], 1L)
+        assertEquals(positive[0], 1L)
+        assertEquals(positive["SomeId", java.lang.Integer::class.java] as Int, 1)
+        assertEquals(positive["SomeId", java.lang.Number::class.java] as Long, 1L)
+        assertEquals(positive[0, java.lang.Integer::class.java] as Int, 1)
+        assertEquals(positive[0, java.lang.Number::class.java] as Long, 1L)
+
+        assertEquals(overflowed["GoodsId"]?.javaClass as Class<*>?, BigInteger::class.java)
+        assertEquals(overflowed["GoodsId", Any::class.java]?.javaClass as Class<*>?, BigInteger::class.java)
+        assertEquals(overflowed["GoodsId"], BigInteger(ULong.MAX_VALUE.toString()))
+        assertEquals(overflowed["goodsId"], BigInteger(ULong.MAX_VALUE.toString()))
+        assertEquals(overflowed["GOODSID"], BigInteger(ULong.MAX_VALUE.toString()))
+        assertEquals(overflowed[0], BigInteger(ULong.MAX_VALUE.toString()))
+        assertEquals(overflowed["GoodsId", java.lang.Long::class.java] as Long, -1L)
+        assertEquals(overflowed["GoodsId", java.lang.Number::class.java] as BigInteger, BigInteger(ULong.MAX_VALUE.toString()))
+        assertEquals(overflowed[0, java.lang.Long::class.java] as Long, -1L)
+        assertEquals(overflowed[0, java.lang.Number::class.java] as BigInteger, BigInteger(ULong.MAX_VALUE.toString()))
+    }
+}


### PR DESCRIPTION
See #137 .

- Allow all primitive types
- Allow Object.class and Number.class
- Add unit test for `JasyncInsertSyntheticRow` and `JasyncInsertSyntheticMetadata`