### PR TITLE
[WIP] Removes JodaTime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 script:
 #  - ./gradlew build -Pnetty_version=4.0.56.Final
 #  - ./gradlew clean build -x test
-#  - ./gradlew :mysq-async:test --tests com.github.jasync.sql.db.mysql.QueryTimeoutSpec --info
+  - ./gradlew :mysql-async:test --tests com.github.jasync.sql.db.mysql.PreparedStatementsSpec --debug
   - ./resources/run-docker-memsql.sh
   - ./gradlew clean build
   - ./resources/detect-leak.sh mysql-async/target/mysql-async-tests.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 script:
 #  - ./gradlew build -Pnetty_version=4.0.56.Final
 #  - ./gradlew clean build -x test
-  - ./gradlew :mysql-async:test --tests com.github.jasync.sql.db.mysql.PreparedStatementsSpec --debug
+  - ./gradlew :mysql-async:test --tests com.github.jasync.sql.db.mysql.PreparedStatementsSpec --info
   - ./resources/run-docker-memsql.sh
   - ./gradlew clean build
   - ./resources/detect-leak.sh mysql-async/target/mysql-async-tests.log

--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ dependencies {
 This project is a port of [mauricio/postgresql-async](https://github.com/mauricio/postgresql-async) to Kotlin.  
 Why? Because the original lib is not maintained anymore, We use it in [ob1k](https://github.com/outbrain/ob1k), and would like to remove the Scala dependency in ob1k.
 
-This project always returns [JodaTime](http://joda-time.sourceforge.net/) when dealing with date types and not the
-`java.util.Date` class. (We plan to move to jdk-8 dates).
-
 If you want information specific to the drivers, check the [PostgreSQL README](postgresql-async/README.md) and the
 [MySQL README](mysql-async/README.md).
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ allprojects {
     compileKotlin {
         kotlinOptions.suppressWarnings = true
         kotlinOptions.jvmTarget = 1.8
-        kotlinOptions.freeCompilerArgs += ["-Xsanitize-parentheses"]
     }
     jacoco {
         toolVersion = "0.8.3"

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ allprojects {
     compileKotlin {
         kotlinOptions.suppressWarnings = true
         kotlinOptions.jvmTarget = 1.8
+        kotlinOptions.freeCompilerArgs += ["-Xsanitize-parentheses"]
     }
     jacoco {
         toolVersion = "0.8.3"

--- a/db-async-common/build.gradle
+++ b/db-async-common/build.gradle
@@ -3,8 +3,6 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines_version"
     implementation "org.slf4j:slf4j-api:$sl4j_version"
-    implementation "joda-time:joda-time:$joda_version"
-    implementation "org.joda:joda-convert:$joda_convert_version"
     implementation "io.netty:netty-transport:$netty_version"
     compileOnly "io.netty:netty-transport-native-epoll:$netty_version:linux-x86_64"
     compileOnly "io.netty:netty-transport-native-kqueue:$netty_version:osx-x86_64"

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/RowData.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/RowData.kt
@@ -1,7 +1,7 @@
 package com.github.jasync.sql.db
 
 import com.github.jasync.sql.db.util.XXX
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 
 /**
  *

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/DateEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/DateEncoderDecoder.kt
@@ -1,27 +1,27 @@
 package com.github.jasync.sql.db.column
 
 import com.github.jasync.sql.db.exceptions.DateEncoderNotAvailableException
-import org.joda.time.LocalDate
-import org.joda.time.ReadablePartial
-import org.joda.time.format.DateTimeFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAccessor
 
 object DateEncoderDecoder : ColumnEncoderDecoder {
 
     private const val ZeroedDate = "0000-00-00"
 
-    private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd") // DateTimeFormat.forPattern("yyyy-MM-dd")
 
     override fun decode(value: String): LocalDate? =
         if (ZeroedDate == value) {
             null
         } else {
-            this.formatter.parseLocalDate(value)
+            LocalDate.parse(value, this.formatter)
         }
 
     override fun encode(value: Any): String {
         return when (value) {
-            is java.sql.Date -> this.formatter.print(LocalDate(value))
-            is ReadablePartial -> this.formatter.print(value)
+            is java.sql.Date -> value.toLocalDate().format(this.formatter)
+            is TemporalAccessor -> this.formatter.format(value)
             else -> throw DateEncoderNotAvailableException(value)
         }
     }

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/DateEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/DateEncoderDecoder.kt
@@ -9,7 +9,7 @@ object DateEncoderDecoder : ColumnEncoderDecoder {
 
     private const val ZeroedDate = "0000-00-00"
 
-    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd") // DateTimeFormat.forPattern("yyyy-MM-dd")
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
     override fun decode(value: String): LocalDate? =
         if (ZeroedDate == value) {

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/InetAddressEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/InetAddressEncoderDecoder.kt
@@ -1,18 +1,10 @@
 package com.github.jasync.sql.db.column
 
-import sun.net.util.IPAddressUtil.textToNumericFormatV4
-import sun.net.util.IPAddressUtil.textToNumericFormatV6
 import java.net.InetAddress
 
 object InetAddressEncoderDecoder : ColumnEncoderDecoder {
 
-    override fun decode(value: String): Any {
-        return if (value.contains(':')) {
-            InetAddress.getByAddress(textToNumericFormatV6(value))
-        } else {
-            InetAddress.getByAddress(textToNumericFormatV4(value))
-        }
-    }
+    override fun decode(value: String): Any = InetAddress.getByName(value)
 
     override fun encode(value: Any): String {
         return (value as InetAddress).hostAddress

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/LocalDateTimeEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/LocalDateTimeEncoderDecoder.kt
@@ -1,28 +1,27 @@
 package com.github.jasync.sql.db.column
 
-import org.joda.time.LocalDateTime
-import org.joda.time.format.DateTimeFormatterBuilder
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatterBuilder
 
 object LocalDateTimeEncoderDecoder : ColumnEncoderDecoder {
 
     private const val ZeroedTimestamp = "0000-00-00 00:00:00"
 
     private val optional = DateTimeFormatterBuilder()
-        .appendPattern(".SSSSSS").toParser()
+        .appendPattern(".SSSSSS").toFormatter()
 
     private val format = DateTimeFormatterBuilder()
         .appendPattern("yyyy-MM-dd HH:mm:ss")
         .appendOptional(optional)
         .toFormatter()
 
-    override fun encode(value: Any): String =
-        format.print(value as LocalDateTime)
+    override fun encode(value: Any): String = (value as LocalDateTime).format(format)
 
     override fun decode(value: String): LocalDateTime? =
         if (ZeroedTimestamp == value) {
             null
         } else {
-            format.parseLocalDateTime(value)
+            LocalDateTime.parse(value, format)
         }
 
 }

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/SQLTimeEncoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/SQLTimeEncoder.kt
@@ -1,7 +1,7 @@
 package com.github.jasync.sql.db.column
 
-import org.joda.time.LocalTime
-import org.joda.time.format.DateTimeFormatterBuilder
+import java.time.LocalTime
+import java.time.format.DateTimeFormatterBuilder
 
 object SQLTimeEncoder : ColumnEncoder {
 
@@ -9,9 +9,5 @@ object SQLTimeEncoder : ColumnEncoder {
         .appendPattern("HH:mm:ss")
         .toFormatter()
 
-    override fun encode(value: Any): String {
-        val time = value as java.sql.Time
-
-        return format.print(LocalTime(time.time))
-    }
+    override fun encode(value: Any): String = (value as java.sql.Time).toLocalTime().format(format)
 }

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimeEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimeEncoderDecoder.kt
@@ -1,7 +1,9 @@
 package com.github.jasync.sql.db.column
 
-import org.joda.time.LocalTime
-import org.joda.time.format.DateTimeFormatterBuilder
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+
 
 open class TimeEncoderDecoder : ColumnEncoderDecoder {
     companion object {
@@ -9,7 +11,7 @@ open class TimeEncoderDecoder : ColumnEncoderDecoder {
     }
 
     private val optional = DateTimeFormatterBuilder()
-        .appendPattern(".SSSSSS").toParser()
+        .appendPattern(".SSSSSS").toFormatter()
 
     private val format = DateTimeFormatterBuilder()
         .appendPattern("HH:mm:ss")
@@ -20,12 +22,10 @@ open class TimeEncoderDecoder : ColumnEncoderDecoder {
         .appendPattern("HH:mm:ss.SSSSSS")
         .toFormatter()
 
-    open fun formatter() = format
+    open fun formatter(): DateTimeFormatter = format
 
-    override fun decode(value: String): LocalTime =
-        format.parseLocalTime(value)
+    override fun decode(value: String): LocalTime = LocalTime.parse(value, format)
 
-    override fun encode(value: Any): String =
-        this.printer.print(value as LocalTime)
+    override fun encode(value: Any): String = (value as LocalTime).format(printer)
 
 }

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimeWithTimezoneEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimeWithTimezoneEncoderDecoder.kt
@@ -1,11 +1,10 @@
 package com.github.jasync.sql.db.column
 
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter
 
 object TimeWithTimezoneEncoderDecoder : TimeEncoderDecoder() {
 
-    private val format = DateTimeFormat.forPattern("HH:mm:ss.SSSSSSZ")
+    private val format = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSZ")
 
     override fun formatter(): DateTimeFormatter = format
 

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimestampEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimestampEncoderDecoder.kt
@@ -1,11 +1,12 @@
 package com.github.jasync.sql.db.column
 
 import com.github.jasync.sql.db.exceptions.DateEncoderNotAvailableException
-import org.joda.time.DateTime
-import org.joda.time.LocalDateTime
-import org.joda.time.ReadableDateTime
-import org.joda.time.format.DateTimeFormatterBuilder
 import java.sql.Timestamp
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.Temporal
+import java.time.temporal.TemporalAccessor
 import java.util.*
 
 
@@ -18,9 +19,9 @@ open class TimestampEncoderDecoder : ColumnEncoderDecoder {
     }
 
     private val optional = DateTimeFormatterBuilder()
-        .appendPattern(MillisFormat).toParser()
+        .appendPattern(MillisFormat).toFormatter()
     private val optionalTimeZone = DateTimeFormatterBuilder()
-        .appendPattern("Z").toParser()
+        .appendPattern("Z").toFormatter()
 
     private val builder = DateTimeFormatterBuilder()
         .appendPattern(BaseFormat)
@@ -38,16 +39,16 @@ open class TimestampEncoderDecoder : ColumnEncoderDecoder {
     open fun formatter() = format
 
     override fun decode(value: String): Any {
-        return formatter().parseLocalDateTime(value)
+        return LocalDateTime.parse(value, formatter())
     }
 
     override fun encode(value: Any): String {
         return when (value) {
-            is Timestamp -> this.timezonedPrinter.print(DateTime(value))
-            is Date -> this.timezonedPrinter.print(DateTime(value))
-            is Calendar -> this.timezonedPrinter.print(DateTime(value))
-            is LocalDateTime -> this.nonTimezonedPrinter.print(value)
-            is ReadableDateTime -> this.timezonedPrinter.print(value)
+            is Timestamp -> value.toLocalDateTime().format(this.timezonedPrinter)
+            is Date -> LocalDateTime.ofInstant(value.toInstant(), ZoneOffset.UTC).format(this.timezonedPrinter)
+            is Calendar -> LocalDateTime.ofInstant(value.toInstant(), ZoneOffset.UTC).format(this.timezonedPrinter)
+            is LocalDateTime -> value.format(this.nonTimezonedPrinter)
+            is TemporalAccessor -> this.timezonedPrinter.format(value)
             else -> throw DateEncoderNotAvailableException(value)
         }
     }

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimestampWithTimezoneEncoderDecoder.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/column/TimestampWithTimezoneEncoderDecoder.kt
@@ -1,16 +1,16 @@
 package com.github.jasync.sql.db.column
 
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.format.DateTimeFormatter
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 object TimestampWithTimezoneEncoderDecoder : TimestampEncoderDecoder() {
 
-    private val format = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSZ")
+    private val format = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSZ")
 
     override fun formatter(): DateTimeFormatter = format
 
     override fun decode(value: String): Any {
-        return formatter().parseDateTime(value)
+        return ZonedDateTime.parse(value, formatter())
     }
 
 }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/RowDataTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/RowDataTest.kt
@@ -1,8 +1,8 @@
 package com.github.jasync.sql.db
 
 import org.assertj.core.api.Assertions.assertThat
-import org.joda.time.LocalDateTime
 import org.junit.Test
+import java.time.LocalDateTime
 
 class RowDataTest {
 

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/column/TimestampEncoderDecoderSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/column/TimestampEncoderDecoderSpec.kt
@@ -1,47 +1,52 @@
 package com.github.jasync.sql.db.column
 
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormatterBuilder
 import org.junit.Test
 import java.sql.Timestamp
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatterBuilder
+import java.util.*
 import kotlin.test.assertEquals
 
 class TimestampEncoderDecoderSpec {
 
     val encoder = TimestampEncoderDecoder()
-    val dateTime = DateTime()
-        .withDate(2013, 12, 27)
-        .withTime(8, 40, 50, 800)
+
+    val localDateTime = LocalDateTime.of(2013, 12, 27,
+            8, 40, 50, 800)
+    val utcInstant = localDateTime.toInstant(ZoneOffset.UTC)
+
+    val legacyDate = Date.from(utcInstant)
 
     val result = "2013-12-27 08:40:50.800000"
     val formatter = DateTimeFormatterBuilder().appendPattern("Z").toFormatter()
-    val resultWithTimezone = "2013-12-27 08:40:50.800000${formatter.print(dateTime)}"
+    val resultWithTimezone = "2013-12-27 08:40:50.800000${localDateTime.format(formatter)}"
 
     @Test
     fun `should print a timestamp`() {
-        val timestamp = Timestamp(dateTime.toDate().time)
+        val timestamp = Timestamp(utcInstant.toEpochMilli())
         assertEquals(encoder.encode(timestamp), resultWithTimezone)
     }
 
     @Test
     fun `should print a LocalDateTime`() {
-        assertEquals(encoder.encode(dateTime.toLocalDateTime()), result)
+        assertEquals(encoder.encode(localDateTime), result)
     }
 
     @Test
     fun `should print a date`() {
-        assertEquals(encoder.encode(dateTime.toDate()), resultWithTimezone)
+        assertEquals(encoder.encode(legacyDate), resultWithTimezone)
     }
 
     @Test
     fun `should print a calendar`() {
         val calendar = java.util.Calendar.getInstance()
-        calendar.time = dateTime.toDate()
+        calendar.time = legacyDate
         encoder.encode(calendar) === resultWithTimezone
     }
 
     @Test
     fun `should print a datetime`() {
-        encoder.encode(dateTime) === resultWithTimezone
+        encoder.encode(localDateTime) === resultWithTimezone
     }
 }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/column/TimestampEncoderDecoderSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/column/TimestampEncoderDecoderSpec.kt
@@ -1,9 +1,10 @@
+
 package com.github.jasync.sql.db.column
 
 import org.junit.Test
 import java.sql.Timestamp
-import java.time.LocalDateTime
-import java.time.ZoneOffset
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatterBuilder
 import java.util.*
 import kotlin.test.assertEquals
@@ -11,42 +12,41 @@ import kotlin.test.assertEquals
 class TimestampEncoderDecoderSpec {
 
     val encoder = TimestampEncoderDecoder()
-
-    val localDateTime = LocalDateTime.of(2013, 12, 27,
-            8, 40, 50, 800)
-    val utcInstant = localDateTime.toInstant(ZoneOffset.UTC)
-
-    val legacyDate = Date.from(utcInstant)
+    val dateTime = ZonedDateTime.of(2013, 12, 27,
+            8, 40, 50, 800 * 1000000,
+            ZoneId.systemDefault())
 
     val result = "2013-12-27 08:40:50.800000"
     val formatter = DateTimeFormatterBuilder().appendPattern("Z").toFormatter()
-    val resultWithTimezone = "2013-12-27 08:40:50.800000${localDateTime.format(formatter)}"
+    val resultWithTimezone = "2013-12-27 08:40:50.800000${dateTime.format(formatter)}"
 
     @Test
     fun `should print a timestamp`() {
-        val timestamp = Timestamp(utcInstant.toEpochMilli())
+
+        Timestamp.from(dateTime.toInstant())
+        val timestamp = Timestamp.from(dateTime.toInstant())
         assertEquals(encoder.encode(timestamp), resultWithTimezone)
     }
 
     @Test
     fun `should print a LocalDateTime`() {
-        assertEquals(encoder.encode(localDateTime), result)
+        assertEquals(encoder.encode(dateTime.toLocalDateTime()), result)
     }
 
     @Test
     fun `should print a date`() {
-        assertEquals(encoder.encode(legacyDate), resultWithTimezone)
+        assertEquals(encoder.encode(Date.from(dateTime.toInstant())), resultWithTimezone)
     }
 
     @Test
     fun `should print a calendar`() {
-        val calendar = java.util.Calendar.getInstance()
-        calendar.time = legacyDate
+        val calendar = Calendar.getInstance()
+        calendar.time = Date.from(calendar.toInstant())
         encoder.encode(calendar) === resultWithTimezone
     }
 
     @Test
     fun `should print a datetime`() {
-        encoder.encode(localDateTime) === resultWithTimezone
+        encoder.encode(dateTime) === resultWithTimezone
     }
 }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -54,7 +54,7 @@ class ActorBasedObjectPoolTest {
     }
 
     @Test
-    fun `basic take operation - when create is little stuck should not be timeout (create timeout is 5 sec)`() {
+    fun `basic take operation - when create is little stuck should not be timeout - create timeout is 5 sec`() {
         tested = ActorBasedObjectPool(
             factory, configuration.copy(
                 createTimeout = 5000
@@ -253,7 +253,7 @@ class ActorBasedObjectPoolTest {
     }
 
     @Test
-    fun `test for leaks detection - we are taking a widget but "lost" it so it should be cleaned up`() {
+    fun `test for leaks detection - we are taking a widget but lost it so it should be cleaned up`() {
         tested = ActorBasedObjectPool(
             ForTestingWeakMyFactory(), configuration.copy(
                 maxObjects = 1,

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/PartitionedAsyncObjectPoolSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/PartitionedAsyncObjectPoolSpec.kt
@@ -150,7 +150,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - before exceed maxObjects - "take maxObjects and receive one back"`() {
+    fun `pool contents - before exceed maxObjects - take maxObjects and receive one back`() {
         takeAndWait(maxObjects)
         pool.giveBack(MyPooledObject(1)).get()
 
@@ -160,7 +160,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - before exceed maxObjects - "take maxObjects and receive one invalid back"`() {
+    fun `pool contents - before exceed maxObjects - take maxObjects and receive one invalid back`() {
         takeAndWait(maxObjects)
         factory.reject += MyPooledObject(1)
         verifyException(ExecutionException::class.java, IllegalStateException::class.java) {
@@ -173,7 +173,7 @@ class PartitionedAsyncObjectPoolSpec {
 
 
     @Test
-    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - "one take queued"`() {
+    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - one take queued`() {
         takeAndWait(maxObjects)
         takeQueued(1)
 
@@ -184,7 +184,7 @@ class PartitionedAsyncObjectPoolSpec {
 
 
     @Test
-    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - "one take queued and receive one item back"`() {
+    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - one take queued and receive one item back`() {
         takeAndWait(maxObjects)
 
         val taking = pool.take()
@@ -200,7 +200,7 @@ class PartitionedAsyncObjectPoolSpec {
     private val Int.toPoolObject: MyPooledObject get() = MyPooledObject(this)
 
     @Test
-    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - "one take queued and receive one invalid item back"`() {
+    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - one take queued and receive one invalid item back`() {
         takeAndWait(maxObjects)
 
         pool.take()
@@ -215,7 +215,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - "maxQueueSize takes queued"`() {
+    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - maxQueueSize takes queued`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -226,7 +226,7 @@ class PartitionedAsyncObjectPoolSpec {
 
 
     @Test
-    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - "maxQueueSize takes queued and receive one back"`() {
+    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - maxQueueSize takes queued and receive one back`() {
         takeAndWait(maxObjects)
 
         val taking = pool.take()
@@ -241,7 +241,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - "maxQueueSize takes queued and receive one invalid back"`() {
+    fun `pool contents - after exceed maxObjects, before exceed maxQueueSize - maxQueueSize takes queued and receive one invalid back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -257,7 +257,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "start to reject takes"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - start to reject takes`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -271,7 +271,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "receive an object back"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - receive an object back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -284,7 +284,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "receive an invalid object back"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - receive an invalid object back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -300,7 +300,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "receive maxQueueSize objects back"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - receive maxQueueSize objects back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -315,7 +315,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "receive maxQueueSize invalid objects back"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - receive maxQueueSize invalid objects back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -332,7 +332,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "receive maxQueueSize + 1 object back"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - receive maxQueueSize + 1 object back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -348,7 +348,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "receive maxQueueSize + 1 invalid object back"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - receive maxQueueSize + 1 invalid object back`() {
         takeAndWait(maxObjects)
         takeQueued(maxQueueSize)
 
@@ -370,7 +370,7 @@ class PartitionedAsyncObjectPoolSpec {
     }
 
     @Test
-    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - "gives back the connection to the original pool"`() {
+    fun `pool contents - after exceed maxObjects, after exceed maxQueueSize - gives back the connection to the original pool`() {
         val executor = Executors.newFixedThreadPool(20)
 
         val takes =

--- a/mysql-async/build.gradle
+++ b/mysql-async/build.gradle
@@ -3,8 +3,6 @@ dependencies {
     compile project(':db-async-common')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.slf4j:slf4j-api:$sl4j_version"
-    compile "joda-time:joda-time:$joda_version"
-    compile "org.joda:joda-convert:$joda_convert_version"
     compile "io.netty:netty-transport:$netty_version"
     compile "io.netty:netty-handler:$netty_version"
     compile "io.github.microutils:kotlin-logging:$kotlin_logging_version"

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/BinaryRowEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/BinaryRowEncoder.kt
@@ -25,17 +25,11 @@ import com.github.jasync.sql.db.mysql.binary.encoder.ShortEncoder
 import com.github.jasync.sql.db.mysql.binary.encoder.StringEncoder
 import com.github.jasync.sql.db.util.XXX
 import io.netty.buffer.ByteBuf
-import org.joda.time.DateTime
-import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
-import org.joda.time.LocalTime
-import org.joda.time.ReadableDateTime
-import org.joda.time.ReadableInstant
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-import java.time.Duration
+import java.time.*
 
 
 class BinaryRowEncoder(charset: Charset) {
@@ -60,7 +54,7 @@ class BinaryRowEncoder(charset: Charset) {
         Double::class.java to DoubleEncoder,
         java.lang.Double::class.java to DoubleEncoder,
         LocalDateTime::class.java to LocalDateTimeEncoder,
-        DateTime::class.java to DateTimeEncoder,
+        ZonedDateTime::class.java to DateTimeEncoder,
         LocalDate::class.java to LocalDateEncoder,
         java.util.Date::class.java to JavaDateEncoder,
         java.sql.Timestamp::class.java to SQLTimestampEncoder,
@@ -79,8 +73,8 @@ class BinaryRowEncoder(charset: Charset) {
                 is CharSequence -> this.stringEncoder
                 is java.math.BigInteger -> this.stringEncoder
                 is BigDecimal -> this.stringEncoder
-                is ReadableDateTime -> DateTimeEncoder
-                is ReadableInstant -> ReadableInstantEncoder
+                is ZonedDateTime -> DateTimeEncoder
+                is Instant -> ReadableInstantEncoder
                 is LocalDateTime -> LocalDateTimeEncoder
                 is java.sql.Timestamp -> SQLTimestampEncoder
                 is java.sql.Date -> SQLDateEncoder

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/decoder/DateDecoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/decoder/DateDecoder.kt
@@ -1,7 +1,7 @@
 package com.github.jasync.sql.db.mysql.binary.decoder
 
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 object DateDecoder : BinaryDecoder {
     override fun decode(buffer: ByteBuf): LocalDate? {

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/decoder/TimestampDecoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/decoder/TimestampDecoder.kt
@@ -2,7 +2,9 @@ package com.github.jasync.sql.db.mysql.binary.decoder
 
 import io.netty.buffer.ByteBuf
 import mu.KotlinLogging
-import org.joda.time.LocalDateTime
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 
 private val logger = KotlinLogging.logger {}
 
@@ -12,37 +14,45 @@ object TimestampDecoder : BinaryDecoder {
 
         return when (size) {
             0.toShort() -> null
-            4.toShort() -> LocalDateTime()
-                .withDate(
-                    buffer.readUnsignedShort(),
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt()
-                )
-                .withTime(0, 0, 0, 0)
-            7.toShort() -> LocalDateTime()
-                .withDate(
-                    buffer.readUnsignedShort(),
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt()
-                )
-                .withTime(
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt(),
-                    0
-                )
-            11.toShort() -> LocalDateTime()
-                .withDate(
-                    buffer.readUnsignedShort(),
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt()
-                )
-                .withTime(
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedByte().toInt(),
-                    buffer.readUnsignedInt().toInt() / 1000
-                )
+            4.toShort() -> LocalDateTime.of(
+                    LocalDate.of(
+                            buffer.readUnsignedShort(),
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt()
+                    ),
+                    LocalTime.of(
+                            0,
+                            0,
+                            0,
+                            0
+                    )
+            )
+            7.toShort() -> LocalDateTime.of(
+                    LocalDate.of(
+                            buffer.readUnsignedShort(),
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt()
+                    ),
+                    LocalTime.of(
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt(),
+                            0
+                    )
+            )
+            11.toShort() -> LocalDateTime.of(
+                    LocalDate.of(
+                            buffer.readUnsignedShort(),
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt()
+                    ),
+                    LocalTime.of(
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt(),
+                            buffer.readUnsignedByte().toInt() / 1000
+                    )
+            )
             else -> {
                 logger.warn { "unknown decoded size $size" }
                 null

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/decoder/TimestampDecoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/decoder/TimestampDecoder.kt
@@ -50,7 +50,7 @@ object TimestampDecoder : BinaryDecoder {
                             buffer.readUnsignedByte().toInt(),
                             buffer.readUnsignedByte().toInt(),
                             buffer.readUnsignedByte().toInt(),
-                            buffer.readUnsignedByte().toInt() / 1000
+                            buffer.readUnsignedByte().toInt() * 1_000_000
                     )
             )
             else -> {

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/CalendarEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/CalendarEncoder.kt
@@ -2,13 +2,14 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.*
 
 object CalendarEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
         val calendar = value as Calendar
-        LocalDateTimeEncoder.encode(LocalDateTime(calendar.timeInMillis), buffer)
+        LocalDateTimeEncoder.encode(LocalDateTime.ofInstant(calendar.toInstant(), ZoneOffset.UTC), buffer)
     }
 
     override fun encodesTo(): Int = ColumnTypes.FIELD_TYPE_TIMESTAMP

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/DateTimeEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/DateTimeEncoder.kt
@@ -2,14 +2,13 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDateTime
-import org.joda.time.ReadableDateTime
+import java.time.ZonedDateTime
 
 object DateTimeEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
-        val instant = value as ReadableDateTime
+        val zdt = value as ZonedDateTime
 
-        return LocalDateTimeEncoder.encode(LocalDateTime(instant.millis), buffer)
+        return LocalDateTimeEncoder.encode(zdt.toLocalDateTime(), buffer)
     }
 
     override fun encodesTo(): Int = ColumnTypes.FIELD_TYPE_TIMESTAMP

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/JavaDateEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/JavaDateEncoder.kt
@@ -2,12 +2,13 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 object JavaDateEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
         val date = value as java.util.Date
-        LocalDateTimeEncoder.encode(LocalDateTime(date.time), buffer)
+        LocalDateTimeEncoder.encode(LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC), buffer)
     }
 
     override fun encodesTo(): Int = ColumnTypes.FIELD_TYPE_TIMESTAMP

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalDateEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalDateEncoder.kt
@@ -2,7 +2,7 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 object LocalDateEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
@@ -10,7 +10,7 @@ object LocalDateEncoder : BinaryEncoder {
 
         buffer.writeByte(4)
         buffer.writeShort(date.year)
-        buffer.writeByte(date.monthOfYear)
+        buffer.writeByte(date.monthValue)
         buffer.writeByte(date.dayOfMonth)
 
     }

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalDateTimeEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalDateTimeEncoder.kt
@@ -2,14 +2,14 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 
 object LocalDateTimeEncoder : BinaryEncoder {
 
     override fun encode(value: Any, buffer: ByteBuf) {
-        val instant = value as LocalDateTime
+        val localDateTime = (value as LocalDateTime)
 
-        val hasMillis = instant.millisOfSecond != 0
+        val hasMillis = localDateTime.nano != 0
 
         if (hasMillis) {
             buffer.writeByte(11)
@@ -17,15 +17,15 @@ object LocalDateTimeEncoder : BinaryEncoder {
             buffer.writeByte(7)
         }
 
-        buffer.writeShort(instant.year)
-        buffer.writeByte(instant.monthOfYear)
-        buffer.writeByte(instant.dayOfMonth)
-        buffer.writeByte(instant.hourOfDay)
-        buffer.writeByte(instant.minuteOfHour)
-        buffer.writeByte(instant.secondOfMinute)
+        buffer.writeShort(localDateTime.year)
+        buffer.writeByte(localDateTime.monthValue)
+        buffer.writeByte(localDateTime.dayOfMonth)
+        buffer.writeByte(localDateTime.hour)
+        buffer.writeByte(localDateTime.minute)
+        buffer.writeByte(localDateTime.second)
 
         if (hasMillis) {
-            buffer.writeInt(instant.millisOfSecond * 1000)
+            buffer.writeInt(localDateTime.nano * 1000)
         }
 
     }

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalTimeEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalTimeEncoder.kt
@@ -7,8 +7,8 @@ import java.time.LocalTime
 object LocalTimeEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
         val time = value as LocalTime
-
-        val hasMillis = time.nano != 0
+        val millis = time.nano * 1_000_000
+        val hasMillis = millis != 0
 
         if (hasMillis) {
             buffer.writeByte(12)
@@ -29,7 +29,7 @@ object LocalTimeEncoder : BinaryEncoder {
         buffer.writeByte(time.second)
 
         if (hasMillis) {
-            buffer.writeInt(time.nano * 1000)
+            buffer.writeInt(millis * 1000)
         }
 
     }

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalTimeEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/LocalTimeEncoder.kt
@@ -2,13 +2,13 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalTime
+import java.time.LocalTime
 
 object LocalTimeEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
         val time = value as LocalTime
 
-        val hasMillis = time.millisOfSecond != 0
+        val hasMillis = time.nano != 0
 
         if (hasMillis) {
             buffer.writeByte(12)
@@ -16,7 +16,7 @@ object LocalTimeEncoder : BinaryEncoder {
             buffer.writeByte(8)
         }
 
-        if (time.millisOfDay > 0) {
+        if (time.toNanoOfDay() > 0) {
             buffer.writeByte(0)
         } else {
             buffer.writeByte(1)
@@ -24,12 +24,12 @@ object LocalTimeEncoder : BinaryEncoder {
 
         buffer.writeInt(0)
 
-        buffer.writeByte(time.hourOfDay)
-        buffer.writeByte(time.minuteOfHour)
-        buffer.writeByte(time.secondOfMinute)
+        buffer.writeByte(time.hour)
+        buffer.writeByte(time.minute)
+        buffer.writeByte(time.second)
 
         if (hasMillis) {
-            buffer.writeInt(time.millisOfSecond * 1000)
+            buffer.writeInt(time.nano * 1000)
         }
 
     }

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/ReadableInstantEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/ReadableInstantEncoder.kt
@@ -2,13 +2,15 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDateTime
-import org.joda.time.ReadableInstant
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 object ReadableInstantEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
-        val date = value as ReadableInstant
-        LocalDateTimeEncoder.encode(LocalDateTime(date.millis), buffer)
+        val instant = value as Instant
+        LocalDateTimeEncoder.encode(LocalDateTime.ofInstant(instant, ZoneOffset.UTC), buffer)
     }
 
     override fun encodesTo(): Int = ColumnTypes.FIELD_TYPE_TIMESTAMP

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/SQLDateEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/SQLDateEncoder.kt
@@ -2,13 +2,12 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDate
 
 object SQLDateEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
         val date = value as java.sql.Date
 
-        LocalDateEncoder.encode(LocalDate(date), buffer)
+        LocalDateEncoder.encode(date.toLocalDate(), buffer)
     }
 
     override fun encodesTo(): Int = ColumnTypes.FIELD_TYPE_DATE

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/SQLTimeEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/SQLTimeEncoder.kt
@@ -2,12 +2,12 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalTime
+import java.time.LocalTime
 
 object SQLTimeEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
-        val sqlTime = (value as java.sql.Time).time
-        val time = LocalTime(sqlTime)
+        val sqlTime = (value as java.sql.Time)
+        val time = sqlTime.toLocalTime()
         LocalTimeEncoder.encode(time, buffer)
     }
 

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/SQLTimestampEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/binary/encoder/SQLTimestampEncoder.kt
@@ -2,12 +2,11 @@ package com.github.jasync.sql.db.mysql.binary.encoder
 
 import com.github.jasync.sql.db.mysql.column.ColumnTypes
 import io.netty.buffer.ByteBuf
-import org.joda.time.LocalDateTime
 
 object SQLTimestampEncoder : BinaryEncoder {
     override fun encode(value: Any, buffer: ByteBuf) {
         val date = value as java.sql.Timestamp
-        LocalDateTimeEncoder.encode(LocalDateTime(date.time), buffer)
+        LocalDateTimeEncoder.encode(date.toLocalDateTime(), buffer)
     }
 
     override fun encodesTo(): Int = ColumnTypes.FIELD_TYPE_TIMESTAMP

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionPoolConfigurationSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionPoolConfigurationSpec.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 class ConnectionPoolConfigurationSpec : ConnectionHelper() {
 
     @Test
-    fun `"configured connection pool" should "be able to run a query"`() {
+    fun `configured connection pool should be able to run a query`() {
         withPoolConfigurationConnectionConnection { connection ->
             assertThat(executeQuery(connection, this.createTable).rowsAffected).isEqualTo(0)
         }
@@ -32,7 +32,7 @@ class ConnectionPoolConfigurationSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"configured connection pool with a builder" should "be able to run a query"`() {
+    fun `configured connection pool with a builder should be able to run a query`() {
         withPoolConfigurationConnectionBuilderConnection { connection ->
             assertThat(executeQuery(connection, this.createTable).rowsAffected).isEqualTo(0)
         }
@@ -54,7 +54,7 @@ class ConnectionPoolConfigurationSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"url configured connection pool" should "be able to run a query"`() {
+    fun `url configured connection pool should be able to run a query`() {
         withPoolUrlConfigurationConnection { connection ->
             assertThat(executeQuery(connection, this.createTable).rowsAffected).isEqualTo(0)
         }

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/PreparedStatementsSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/PreparedStatementsSpec.kt
@@ -271,7 +271,7 @@ class PreparedStatementsSpec : ConnectionHelper() {
                 Duration.ofMillis(19)
 
         val timestamp = LocalDateTime.of(2013, 1, 19, 3, 14,
-                7, 19)
+                7, 19 * 1000000)
         val select = "SELECT * FROM posts"
 
         withConnection { connection ->

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/PreparedStatementsSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/PreparedStatementsSpec.kt
@@ -5,13 +5,13 @@ import com.github.jasync.sql.db.interceptor.QueryInterceptor
 import com.github.jasync.sql.db.invoke
 import com.github.jasync.sql.db.util.map
 import org.assertj.core.api.Assertions.assertThat
-import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
 import org.junit.Test
 import org.slf4j.MDC
 import java.math.BigDecimal
 import java.sql.Timestamp
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.function.Supplier
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -82,29 +82,29 @@ class PreparedStatementsSpec : ConnectionHelper() {
             executeQuery(connection, insertTableTimeColumns)
             val result =
                 assertNotNull(assertNotNull(executePreparedStatement(connection, "SELECT * FROM posts").rows)[0])
-            val date = result["created_at_date"] as org.joda.time.LocalDate
+            val date = result["created_at_date"] as LocalDate
 
             assertEquals(2038, date.year)
-            assertEquals(1, date.monthOfYear)
+            assertEquals(1, date.monthValue)
             assertEquals(19, date.dayOfMonth)
 
-            val dateTime = result["created_at_datetime"] as org.joda.time.LocalDateTime
+            val dateTime = result["created_at_datetime"] as LocalDateTime
 
             assertEquals(2013, dateTime.year)
-            assertEquals(1, dateTime.monthOfYear)
+            assertEquals(1, dateTime.monthValue)
             assertEquals(19, dateTime.dayOfMonth)
-            assertEquals(3, dateTime.hourOfDay)
-            assertEquals(14, dateTime.minuteOfHour)
-            assertEquals(7, dateTime.secondOfMinute)
+            assertEquals(3, dateTime.hour)
+            assertEquals(14, dateTime.minute)
+            assertEquals(7, dateTime.second)
 
-            val timestamp = result["created_at_timestamp"] as org.joda.time.LocalDateTime
+            val timestamp = result["created_at_timestamp"] as LocalDateTime
 
             assertEquals(2020, timestamp.year)
-            assertEquals(1, timestamp.monthOfYear)
+            assertEquals(1, timestamp.monthValue)
             assertEquals(19, timestamp.dayOfMonth)
-            assertEquals(3, timestamp.hourOfDay)
-            assertEquals(14, timestamp.minuteOfHour)
-            assertEquals(7, timestamp.secondOfMinute)
+            assertEquals(3, timestamp.hour)
+            assertEquals(14, timestamp.minute)
+            assertEquals(7, timestamp.second)
 
             assertEquals(
                 Duration.ofHours(3).plus(Duration.ofMinutes(14).plus(Duration.ofSeconds(7))),
@@ -221,9 +221,9 @@ class PreparedStatementsSpec : ConnectionHelper() {
           values ( ?, ?, ?, ?, ? )
         """
 
-        val date = LocalDate(2011, 9, 8)
-        val dateTime = LocalDateTime(2012, 5, 27, 15, 29, 55)
-        val timestamp = Timestamp(dateTime.toDateTime().millis)
+        val date = LocalDate.of(2011, 9, 8)
+        val dateTime = LocalDateTime.of(2012, 5, 27, 15, 29, 55)
+        val timestamp = Timestamp.valueOf(dateTime)
         val time = Duration.ofHours(3) + Duration.ofMinutes(5) + Duration.ofSeconds(10)
         val year = 2012.toShort()
 
@@ -242,7 +242,7 @@ class PreparedStatementsSpec : ConnectionHelper() {
             val row = assertNotNull(rows[0])
 
             assertEquals(date, row["created_at_date"])
-            assertEquals(LocalDateTime(timestamp.time), row["created_at_timestamp"])
+            assertEquals(timestamp.toLocalDateTime(), row["created_at_timestamp"])
             assertEquals(time, row["created_at_time"])
             assertEquals(year, row["created_at_year"])
             assertEquals(dateTime, row["created_at_datetime"])
@@ -270,7 +270,8 @@ class PreparedStatementsSpec : ConnectionHelper() {
                 Duration.ofSeconds(7) +
                 Duration.ofMillis(19)
 
-        val timestamp = LocalDateTime(2013, 1, 19, 3, 14, 7, 19)
+        val timestamp = LocalDateTime.of(2013, 1, 19, 3, 14,
+                7, 19)
         val select = "SELECT * FROM posts"
 
         withConnection { connection ->
@@ -358,7 +359,7 @@ class PreparedStatementsSpec : ConnectionHelper() {
                 connection,
                 "CREATE TEMPORARY TABLE timestamps ( id INT NOT NULL, moment TIMESTAMP NULL, primary key (id))"
             )
-            val moment = LocalDateTime.now().withMillisOfDay(0) // cut off millis to match timestamp
+            val moment = LocalDateTime.now().withNano(0) // cut off millis to match timestamp
             executePreparedStatement(
                 connection,
                 "INSERT INTO timestamps (moment, id) VALUES (?, ?)",

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QuerySpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QuerySpec.kt
@@ -11,12 +11,12 @@ import com.github.jasync.sql.db.mysql.exceptions.MySQLException
 import com.github.jasync.sql.db.util.map
 import io.netty.util.CharsetUtil
 import org.assertj.core.api.Assertions.assertThat
-import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
 import org.junit.Test
 import org.slf4j.MDC
 import java.math.BigDecimal
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.concurrent.ExecutionException
 import java.util.function.Supplier
 
@@ -24,7 +24,7 @@ class QuerySpec : ConnectionHelper() {
 
 
     @Test
-    fun `"connection" should "be able to run a DML query"`() {
+    fun `connection should be able to run a DML query`() {
         withConnection { connection ->
             assertThat(executeQuery(connection, this.createTable).rowsAffected).isEqualTo(0)
         }
@@ -32,7 +32,7 @@ class QuerySpec : ConnectionHelper() {
 
 
     @Test
-    fun `"connection" should   "raise an exception upon a bad statement" `() {
+    fun `connection should   raise an exception upon a bad statement `() {
         withConnection { connection ->
             val e = verifyException(ExecutionException::class.java, MySQLException::class.java) {
                 executeQuery(connection, "this is not SQL")
@@ -43,7 +43,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "raise an exception upon incorrect user" `() {
+    fun `connection should   raise an exception upon incorrect user `() {
         val e = verifyException(ExecutionException::class.java, MySQLException::class.java) {
             withConfigurableOpenConnection(ContainerHelper.defaultConfiguration.copy(username = "not exists")) { connection ->
                 executeQuery(connection, "select 1")
@@ -55,7 +55,7 @@ class QuerySpec : ConnectionHelper() {
 
 
     @Test
-    fun `"connection" should   "be able to select from a table" `() {
+    fun `connection should   be able to select from a table `() {
 
         withConnection { connection ->
             assertThat(executeQuery(connection, this.createTable).rowsAffected).isEqualTo(0)
@@ -87,7 +87,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "be able to select from a table" - validate columnNames()`() {
+    fun `connection should   be able to select from a table - validate columnNames`() {
 
         withConnection { connection ->
             assertThat(executeQuery(connection, this.createTable).rowsAffected).isEqualTo(0)
@@ -100,7 +100,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "be able to select from a table with timestamps" `() {
+    fun `connection should   be able to select from a table with timestamps `() {
 
         withConnection { connection ->
             executeQuery(connection, createTableTimeColumns)
@@ -109,25 +109,25 @@ class QuerySpec : ConnectionHelper() {
 
             val date = result("created_at_date") as LocalDate
 
-            assertThat(date.getYear()).isEqualTo(2038)
-            assertThat(date.getMonthOfYear()).isEqualTo(1)
-            assertThat(date.getDayOfMonth()).isEqualTo(19)
+            assertThat(date.year).isEqualTo(2038)
+            assertThat(date.monthValue).isEqualTo(1)
+            assertThat(date.dayOfMonth).isEqualTo(19)
 
             val dateTime = result("created_at_datetime") as LocalDateTime
-            assertThat(dateTime.getYear()).isEqualTo(2013)
-            assertThat(dateTime.getMonthOfYear()).isEqualTo(1)
-            assertThat(dateTime.getDayOfMonth()).isEqualTo(19)
-            assertThat(dateTime.getHourOfDay()).isEqualTo(3)
-            assertThat(dateTime.getMinuteOfHour()).isEqualTo(14)
-            assertThat(dateTime.getSecondOfMinute()).isEqualTo(7)
+            assertThat(dateTime.year).isEqualTo(2013)
+            assertThat(dateTime.monthValue).isEqualTo(1)
+            assertThat(dateTime.dayOfMonth).isEqualTo(19)
+            assertThat(dateTime.hour).isEqualTo(3)
+            assertThat(dateTime.minute).isEqualTo(14)
+            assertThat(dateTime.second).isEqualTo(7)
 
             val timestamp = result("created_at_timestamp") as LocalDateTime
-            assertThat(timestamp.getYear()).isEqualTo(2020)
-            assertThat(timestamp.getMonthOfYear()).isEqualTo(1)
-            assertThat(timestamp.getDayOfMonth()).isEqualTo(19)
-            assertThat(timestamp.getHourOfDay()).isEqualTo(3)
-            assertThat(timestamp.getMinuteOfHour()).isEqualTo(14)
-            assertThat(timestamp.getSecondOfMinute()).isEqualTo(7)
+            assertThat(timestamp.year).isEqualTo(2020)
+            assertThat(timestamp.monthValue).isEqualTo(1)
+            assertThat(timestamp.dayOfMonth).isEqualTo(19)
+            assertThat(timestamp.hour).isEqualTo(3)
+            assertThat(timestamp.minute).isEqualTo(14)
+            assertThat(timestamp.second).isEqualTo(7)
 
 
             assertThat(result("created_at_time")).isEqualTo(
@@ -146,7 +146,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "be able to select from a table with the various numeric types" `() {
+    fun `connection should   be able to select from a table with the various numeric types `() {
 
         withConnection { connection ->
             executeQuery(connection, createTableNumericColumns)
@@ -166,7 +166,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "be able to read from a BLOB column when in text protocol" `() {
+    fun `connection should   be able to read from a BLOB column when in text protocol `() {
         val create = """CREATE TEMPORARY TABLE posts (
                    |       id INT NOT NULL AUTO_INCREMENT,
                    |       some_bytes BLOB not null,
@@ -186,7 +186,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "have column names on result set" `() {
+    fun `connection should   have column names on result set `() {
 
         val create = """CREATE TEMPORARY TABLE posts (
                    |       id INT NOT NULL AUTO_INCREMENT,
@@ -228,7 +228,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "support BIT type" `() {
+    fun `connection should   support BIT type `() {
 
         val create =
             """CREATE TEMPORARY TABLE POSTS (
@@ -254,7 +254,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "fail if number of args required is different than the number of provided parameters" `() {
+    fun `connection should   fail if number of args required is different than the number of provided parameters `() {
 
         withConnection { connection ->
             verifyException(InsufficientParametersException::class.java) {
@@ -269,7 +269,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "select from another empty table with many columns" `() {
+    fun `connection should   select from another empty table with many columns `() {
         withConnection { connection ->
             val create = """create temporary table test_11 (
                        |    id int primary key not null,
@@ -288,7 +288,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "select from an empty table with many columns" `() {
+    fun `connection should   select from an empty table with many columns `() {
 
         withConnection { connection ->
 
@@ -309,7 +309,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection" should   "select from a json column" `() {
+    fun `connection should   select from a json column `() {
 
         val create = "create temporary table jsons (id char(4), data json)"
 
@@ -330,7 +330,7 @@ class QuerySpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection interceptor" should  have mdc values visible `() {
+    fun `connection interceptor should  have mdc values visible `() {
 
         val interceptor = ForTestingQueryInterceptor()
         MDC.put("a", "b")

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QueryTimeoutSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QueryTimeoutSpec.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeoutException
 class QueryTimeoutSpec : ConnectionHelper() {
 
     @Test
-    fun `"Simple query with short timeout"`() {
+    fun `Simple query with short timeout`() {
         withConfigurablePool(shortTimeoutConfiguration()) { pool ->
             val connection = pool.take().get(10, TimeUnit.SECONDS)
             assertThat(connection.isTimeout()).isEqualTo(false)
@@ -32,7 +32,7 @@ class QueryTimeoutSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"Simple query with short timeout directly on pool"`() {
+    fun `Simple query with short timeout directly on pool`() {
         withConfigurablePool(shortTimeoutConfiguration()) { pool ->
             val queryResultFuture = pool.sendQuery("select sleep(100)")
             verifyException(ExecutionException::class.java, TimeoutException::class.java) {
@@ -43,7 +43,7 @@ class QueryTimeoutSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"Simple query with 5 sec timeout"`() {
+    fun `Simple query with 5 sec timeout`() {
         withConfigurablePool(longTimeoutConfiguration()) { pool ->
             val connection = pool.take().get(10, TimeUnit.SECONDS)
             assertThat(connection.isTimeout()).isEqualTo(false)

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/StoredProceduresSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/StoredProceduresSpec.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class StoredProceduresSpec : ConnectionHelper() {
 
     @Test
-    fun `"be able to execute create stored procedure"`() {
+    fun `be able to execute create stored procedure`() {
         withConnection { connection ->
             connection.sendQuery("DROP PROCEDURE IF exists helloWorld;").get()
             val result = connection.sendQuery(
@@ -26,7 +26,7 @@ class StoredProceduresSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"be able to call stored procedure"`() {
+    fun `be able to call stored procedure`() {
         withConnection { connection ->
             connection.sendQuery("DROP PROCEDURE IF exists constTest;").get()
             connection.sendQuery(
@@ -45,7 +45,7 @@ class StoredProceduresSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"be able to call stored procedure - reproduce ok message sent after EOF"`() {
+    fun `be able to call stored procedure - reproduce ok message sent after EOF`() {
         withConnection { connection ->
             connection.sendQuery("DROP PROCEDURE IF exists constTest;").get()
             connection.sendQuery(
@@ -64,7 +64,7 @@ class StoredProceduresSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"be able to call stored procedure with input parameter"`() {
+    fun `be able to call stored procedure with input parameter`() {
         withConnection { connection ->
             connection.sendQuery("DROP PROCEDURE IF exists addTest;").get()
             connection.sendQuery(
@@ -84,7 +84,7 @@ class StoredProceduresSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"be able to remove stored procedure"`() {
+    fun `be able to remove stored procedure`() {
         withConnection { connection ->
             connection.sendQuery("DROP PROCEDURE IF exists remTest;").get()
             connection.sendQuery(

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/TransactionSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/TransactionSpec.kt
@@ -16,7 +16,7 @@ val TransactionInsert = "insert into transaction_test (id) values (?)"
 class TransactionSpec : ConnectionHelper() {
 
     @Test
-    fun `"connection in transaction" should "correctly store the values of the transaction"`() {
+    fun `connection in transaction should correctly store the values of the transaction`() {
         withConnection { connection ->
             executeQuery(connection, this.createTable)
 
@@ -52,7 +52,7 @@ class TransactionSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection in transaction" should "correctly rollback changes if the transaction raises an exception"`() {
+    fun `connection in transaction should correctly rollback changes if the transaction raises an exception`() {
 
         withConnection { connection ->
             executeQuery(connection, this.createTable)
@@ -78,7 +78,7 @@ class TransactionSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection in transaction" should "should make a connection invalid and not return it to the pool if it raises an exception"`() {
+    fun `connection in transaction should should make a connection invalid and not return it to the pool if it raises an exception`() {
 
 
         withPool { pool ->
@@ -102,7 +102,7 @@ class TransactionSpec : ConnectionHelper() {
     }
 
     @Test
-    fun `"connection in transaction" should "runs commands for a transaction in a single connection"`() {
+    fun `connection in transaction should runs commands for a transaction in a single connection`() {
 
         val id = UUID.randomUUID().toString()
 

--- a/postgresql-async/build.gradle
+++ b/postgresql-async/build.gradle
@@ -3,8 +3,6 @@ dependencies {
     compile project(':db-async-common')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.slf4j:slf4j-api:$sl4j_version"
-    compile "joda-time:joda-time:$joda_version"
-    compile "org.joda:joda-convert:$joda_convert_version"
     compile "io.netty:netty-transport:$netty_version"
     compile "io.netty:netty-handler:$netty_version"
     compile "io.github.microutils:kotlin-logging:$kotlin_logging_version"

--- a/r2dbc-mysql/build.gradle
+++ b/r2dbc-mysql/build.gradle
@@ -5,8 +5,6 @@ dependencies {
     compile "io.r2dbc:r2dbc-spi:0.8.0.M8"
     implementation "io.projectreactor:reactor-core:3.2.6.RELEASE"
     compile "org.slf4j:slf4j-api:$sl4j_version"
-    compile "joda-time:joda-time:$joda_version"
-    compile "org.joda:joda-convert:$joda_convert_version"
     compile "io.netty:netty-transport:$netty_version"
     compile "io.netty:netty-handler:$netty_version"
     compile "io.github.microutils:kotlin-logging:$kotlin_logging_version"

--- a/versions.gradle
+++ b/versions.gradle
@@ -4,8 +4,6 @@
 ext.kotlin_version='1.3.21'
 ext.kotlinx_coroutines_version='1.1.1'
 ext.sl4j_version='1.7.25'
-ext.joda_version='2.9.7'
-ext.joda_convert_version='1.8.1'
 ext.netty_version='4.1.34.Final'
 ext.kotlin_logging_version='1.6.23'
 


### PR DESCRIPTION
I don't want a dependency on JodaTime for my projects, so I decided to start fixing #131 

TODO:
[x] Common library
[x] MySQL
[x] Fix TimestampEncoder
[ ] Fix MySQL tests
[] Postgres
[] Fix Postgres tests

Looking for comments on this before I finish the whole thing (ideally from someone who has in depth knowledge of `java.time`) - I'm not 100% sure I've converted the calls successfully in some cases. Mostly followed this as a guide: https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html

Implementation notes:
~TimestampEncoder is definitely broken, probably need to use ZonedDateTime instead of LocalDateTime etc. Will take a look at it later and resolve.~ Even though TimestampEncoder assumes no time zone, it formats times using a 'Z' suffix to represent the UTC timezone. As such, I had to make it use `ZonedDateTime` otherwise a formatting exception would occur at runtime.

Cheers