### PR TITLE
fix connection factory validation to return success when appropriate

### DIFF
--- a/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
+++ b/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
@@ -3,7 +3,7 @@ package com.github.jasync.r2dbc.mysql
 
 import com.github.jasync.sql.db.mysql.MySQLConnection
 import com.github.jasync.sql.db.mysql.pool.MySQLConnectionFactory
-import com.github.jasync.sql.db.util.isSuccess
+import com.github.jasync.sql.db.util.map
 import io.r2dbc.spi.Batch
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionMetadata
@@ -27,7 +27,7 @@ class JasyncClientConnection(
         return when (depth) {
             ValidationDepth.LOCAL -> mySQLConnectionFactory.validate(jasyncConnection as MySQLConnection).isSuccess.toMono()
             ValidationDepth.REMOTE -> Mono.defer {
-                mySQLConnectionFactory.test(jasyncConnection as MySQLConnection).isSuccess.toMono()
+                mySQLConnectionFactory.test(jasyncConnection as MySQLConnection).map { true }.toMono()
             }
         }
     }


### PR DESCRIPTION
the connection returned always false because it was not waiting for the
future to complete
fix is to map the valid connection to true

Fixes #161 