### PR TITLE
Pool - inTransaction is not executed on one connection

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ConnectionPool.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ConnectionPool.kt
@@ -100,6 +100,19 @@ class ConnectionPool<T : ConcreteConnection>(
         objectPool.use(configuration.executionContext) { it.inTransaction(f) }
 
     /**
+     *
+     * Picks one connection and executes an (asynchronous) function on it.
+     * The connection is returned to the pool on completion.
+     *
+     * @param f operation to execute on a connection
+     * @return result of f
+     */
+
+    fun <A> use(f: (Connection) -> CompletableFuture<A>)
+            : CompletableFuture<A> =
+        objectPool.use(configuration.executionContext) { f(it) }
+
+    /**
      * The number of connections that are currently in use for queries
      */
     val inUseConnectionsCount: Int get() = objectPool.usedItemsSize
@@ -132,4 +145,5 @@ class ConnectionPool<T : ConcreteConnection>(
     override fun connect(): CompletableFuture<Connection> = CompletableFuture.completedFuture(this)
 
     override fun isConnected(): Boolean = !objectPool.closed
+
 }

--- a/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnection.kt
+++ b/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnection.kt
@@ -144,6 +144,7 @@ class PostgreSQLConnection @JvmOverloads constructor(
     fun parameterStatuses(): Map<String, String> = this.parameterStatus.toMap()
 
     override fun sendQueryDirect(query: String): CompletableFuture<QueryResult> {
+        logger.trace { "sendQueryDirect - $connectionId $query" }
         validateQuery(query)
 
         val promise = CompletableFuture<QueryResult>()
@@ -155,6 +156,7 @@ class PostgreSQLConnection @JvmOverloads constructor(
     }
 
     override fun sendPreparedStatementDirect(params: PreparedStatementParams): CompletableFuture<QueryResult> {
+        logger.trace { "sendPreparedStatementDirect - $connectionId $params" }
         validateQuery(params.query)
 
         val promise = CompletableFuture<QueryResult>()

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/TransactionSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/TransactionSpec.kt
@@ -14,18 +14,18 @@ import java.util.concurrent.ExecutionException
 class TransactionSpec : DatabaseTestHelper() {
 
 
-    val tableCreate = "CREATE TEMP TABLE transaction_test (x integer PRIMARY KEY)"
+    private val tableCreate = "CREATE TEMP TABLE transaction_test (x integer PRIMARY KEY)"
 
-    fun tableInsert(x: Int) = "INSERT INTO transaction_test VALUES (" + x.toString() + ")"
+    private fun tableInsert(x: Int) = "INSERT INTO transaction_test VALUES ($x)"
 
-    val tableSelect = "SELECT x FROM transaction_test ORDER BY x"
+    private val tableSelect = "SELECT x FROM transaction_test ORDER BY x"
 
     @Test
     fun `"transactions" should "commit simple inserts"`() {
         withHandler { handler ->
             executeDdl(handler, tableCreate)
             awaitFuture(handler.inTransaction { conn ->
-                conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
+                conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) {
                     conn.sendQuery(tableInsert(2))
                 }
             })
@@ -42,7 +42,7 @@ class TransactionSpec : DatabaseTestHelper() {
         withHandler { handler ->
             executeDdl(handler, tableCreate)
             awaitFuture(handler.inTransaction { conn ->
-                conn.sendPreparedStatement(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
+                conn.sendPreparedStatement(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) {
                     conn.sendPreparedStatement(tableInsert(2))
                 }
             })
@@ -62,7 +62,7 @@ class TransactionSpec : DatabaseTestHelper() {
             val e: GenericDatabaseException =
                 verifyException(ExecutionException::class.java, GenericDatabaseException::class.java) {
                     awaitFuture(handler.inTransaction { conn ->
-                        conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
+                        conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) {
                             conn.sendQuery(tableInsert(1))
                         }
                     })
@@ -82,7 +82,7 @@ class TransactionSpec : DatabaseTestHelper() {
         withHandler { handler ->
             executeDdl(handler, tableCreate)
             awaitFuture(handler.inTransaction { conn ->
-                conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
+                conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) {
                     conn.sendQuery("ROLLBACK")
                 }
             })
@@ -98,9 +98,9 @@ class TransactionSpec : DatabaseTestHelper() {
         withHandler { handler ->
             executeDdl(handler, tableCreate)
             awaitFuture(handler.inTransaction { conn ->
-                conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
-                    conn.sendQuery("SAVEPOINT one").flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
-                        conn.sendQuery(tableInsert(2)).flatMapAsync(ExecutorServiceUtils.CommonPool) { _ ->
+                conn.sendQuery(tableInsert(1)).flatMapAsync(ExecutorServiceUtils.CommonPool) {
+                    conn.sendQuery("SAVEPOINT one").flatMapAsync(ExecutorServiceUtils.CommonPool) {
+                        conn.sendQuery(tableInsert(2)).flatMapAsync(ExecutorServiceUtils.CommonPool) {
                             conn.sendQuery("ROLLBACK TO SAVEPOINT one")
                         }
                     }

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/ConnectionPoolSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/ConnectionPoolSpec.kt
@@ -2,36 +2,36 @@ package com.github.aysnc.sql.db.integration.pool
 
 import com.github.aysnc.sql.db.integration.DatabaseTestHelper
 import com.github.aysnc.sql.db.verifyException
+import com.github.jasync.sql.db.ConcreteConnection
 import com.github.jasync.sql.db.invoke
 import com.github.jasync.sql.db.postgresql.exceptions.GenericDatabaseException
 import com.github.jasync.sql.db.util.ExecutorServiceUtils
 import com.github.jasync.sql.db.util.flatMapAsync
 import com.github.jasync.sql.db.util.mapAsync
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.*
 import java.util.concurrent.ExecutionException
 
 
 class ConnectionPoolSpec : DatabaseTestHelper() {
-    private val Insert = "insert into transaction_test (id) values (?)"
+    private val insertQuery = "insert into transaction_test (id) values (?)"
 
 
     @Test
     fun `"pool" should "give you a connection when sending statements"`() {
-
         withPool { pool ->
-            assertThat(executeQuery(pool, "SELECT 8").rows.get(0)(0)).isEqualTo(8)
+            assertThat(executeQuery(pool, "SELECT 8").rows[0](0)).isEqualTo(8)
             Thread.sleep(1000)
             assertThat(pool.idleConnectionsCount).isEqualTo(1)
         }
-
     }
 
     @Test
     fun `"pool" should "give you a connection for prepared statements"`() {
         withPool { pool ->
-            assertThat(executePreparedStatement(pool, "SELECT 8").rows.get(0)(0)).isEqualTo(8)
+            assertThat(executePreparedStatement(pool, "SELECT 8").rows[0](0)).isEqualTo(8)
             Thread.sleep(1000)
             assertThat(pool.idleConnectionsCount).isEqualTo(1)
         }
@@ -46,14 +46,13 @@ class ConnectionPoolSpec : DatabaseTestHelper() {
 
     @Test
     fun `"pool" should "runs commands for a transaction in a single connection" `() {
-
         val id = UUID.randomUUID().toString()
 
         withPool { pool ->
             val operations = pool.inTransaction { connection ->
-                connection.sendPreparedStatement(Insert, listOf(id))
+                connection.sendPreparedStatement(insertQuery, listOf(id))
                     .flatMapAsync(ExecutorServiceUtils.CommonPool) { result ->
-                        connection.sendPreparedStatement(Insert, listOf(id))
+                        connection.sendPreparedStatement(insertQuery, listOf(id))
                             .mapAsync(ExecutorServiceUtils.CommonPool) { failure ->
                                 listOf(result, failure)
                             }
@@ -62,11 +61,17 @@ class ConnectionPoolSpec : DatabaseTestHelper() {
             verifyException(ExecutionException::class.java, GenericDatabaseException::class.java) {
                 awaitFuture(operations)
             }
-
         }
-
     }
 
-
+    @Test
+    fun `pool should run queries in use with single connection`() {
+        withPool { pool ->
+            pool.use {connection ->
+                assertTrue(connection is ConcreteConnection)
+                connection.sendQuery("SELECT 2")
+            }
+        }
+    }
 
 }

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/SuspendingPoolSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/SuspendingPoolSpec.kt
@@ -129,6 +129,8 @@ class SuspendingPoolSpec : DatabaseTestHelper() {
                 tested.sendQuery(tableCreate)
                 tested.inTransaction { suspConnection ->
                     suspConnection.sendPreparedStatement(tableInsert(1))
+                    // this makes sure if connection is released that it will not be reused
+                    pool.sendQuery("SLEEP 100")
                     delay(500)
                     suspConnection.sendPreparedStatement(tableInsert(2))
                 }

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/SuspendingPoolSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/pool/SuspendingPoolSpec.kt
@@ -1,0 +1,170 @@
+package com.github.aysnc.sql.db.integration.pool
+
+import com.github.aysnc.sql.db.integration.DatabaseTestHelper
+import com.github.aysnc.sql.db.verifyException
+import com.github.jasync.sql.db.asSuspending
+import com.github.jasync.sql.db.invoke
+import com.github.jasync.sql.db.pool.PoolAlreadyTerminatedException
+import com.github.jasync.sql.db.postgresql.exceptions.GenericDatabaseException
+import com.github.jasync.sql.db.util.length
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert
+import org.junit.Test
+import java.util.concurrent.ThreadLocalRandom
+
+class SuspendingPoolSpec : DatabaseTestHelper() {
+
+    private val tableCreate = "CREATE TEMP TABLE transaction_test (x integer PRIMARY KEY)"
+
+    private fun tableInsert(x: Int) = "INSERT INTO transaction_test VALUES ($x)"
+
+    private val tableSelect = "SELECT x FROM transaction_test ORDER BY x"
+
+
+    @Test
+    fun `SuspendingConnection pool 'connect' should not do anything`() {
+        withPool { pool ->
+            runBlocking {
+                val tested = pool.asSuspending
+                val connection = tested.connect()
+                assertThat(connection).isEqualTo(pool)
+            }
+        }
+    }
+
+    @Test
+    fun `SuspendingConnection pool 'disconnect' should not allow more queries`() {
+        withPool { pool ->
+            runBlocking {
+                val tested = pool.asSuspending
+                val connection = tested.disconnect()
+                try {
+                    connection.sendQuery("select 1")
+                    Assert.fail("should not allow queries")
+                } catch (e: PoolAlreadyTerminatedException) {
+                    println("exception caught as expected")
+                    //it is ok
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `SuspendingConnection pool simple send query`() {
+        withPool { pool ->
+            runBlocking {
+                val tested = pool.asSuspending
+                val result = tested.sendQuery("select 3")
+                assertThat(result.rows[0][0]).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test
+    fun `SuspendingConnection pool simple send prepared statement`() {
+        withPool { pool ->
+            runBlocking {
+                val tested = pool.asSuspending
+                val result1 = tested.sendPreparedStatement("select 3")
+                assertThat(result1.rows[0][0]).isEqualTo(3)
+                val result2 = tested.sendPreparedStatement("select 3", listOf())
+                assertThat(result2.rows[0][0]).isEqualTo(3)
+                val result3 = tested.sendPreparedStatement("select 3", listOf(), true)
+                assertThat(result3.rows[0][0]).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test
+    fun `"transactions" should "commit simple inserts , prepared statements"`() {
+        withHandler { connection ->
+            val tested = connection.asSuspending
+            runBlocking {
+                tested.sendQuery(tableCreate)
+                tested.inTransaction { suspConnection ->
+                    suspConnection.sendPreparedStatement(tableInsert(1))
+                    delay(500)
+                    suspConnection.sendPreparedStatement(tableInsert(2))
+                }
+
+                val rows = tested.sendPreparedStatement(tableSelect).rows
+                assertThat(rows.length).isEqualTo(2)
+                assertThat(rows(0)(0)).isEqualTo(1)
+                assertThat(rows(1)(0)).isEqualTo(2)
+            }
+        }
+    }
+
+    @Test
+    fun `"transactions" should "rollback on error"`() {
+        withHandler { connection ->
+            val tested = connection.asSuspending
+            runBlocking {
+                tested.sendQuery(tableCreate)
+                tested.inTransaction { suspConnection ->
+                    suspConnection.sendPreparedStatement(tableInsert(1))
+                    val e: GenericDatabaseException =
+                            verifyException(GenericDatabaseException::class.java) {
+                                runBlocking {
+                                    suspConnection.sendPreparedStatement(tableInsert(1))
+                                }
+                            } as GenericDatabaseException
+                    assertThat(e.errorMessage.message).isEqualTo("duplicate key value violates unique constraint \"transaction_test_pkey\"")
+                }
+            }
+
+            val rows = executeQuery(connection, tableSelect).rows
+            assertThat(rows.length).isEqualTo(0)
+        }
+
+    }
+
+    @Test
+    fun `"transactions" with pool should "commit simple inserts , prepared statements"`() {
+        withPool { pool ->
+            val tested = pool.asSuspending
+            runBlocking {
+                tested.sendQuery(tableCreate)
+                tested.inTransaction { suspConnection ->
+                    suspConnection.sendPreparedStatement(tableInsert(1))
+                    delay(500)
+                    suspConnection.sendPreparedStatement(tableInsert(2))
+                }
+
+                val rows = tested.sendPreparedStatement(tableSelect).rows
+                assertThat(rows.length).isEqualTo(2)
+                assertThat(rows(0)(0)).isEqualTo(1)
+                assertThat(rows(1)(0)).isEqualTo(2)
+            }
+        }
+    }
+
+    @Test
+    fun `"transactions" with pool should "rollback on error"`() {
+        val uniqID = ThreadLocalRandom.current().nextInt(100000)
+        val tableName = "transaction_test_$uniqID"
+        withPool { connection ->
+            val tested = connection.asSuspending
+            runBlocking {
+                tested.sendQuery("CREATE TABLE $tableName (x integer PRIMARY KEY)")
+                tested.inTransaction { suspConnection ->
+                    suspConnection.sendPreparedStatement("INSERT INTO $tableName VALUES (1)")
+                    val e: GenericDatabaseException =
+                            verifyException(GenericDatabaseException::class.java) {
+                                runBlocking {
+                                    suspConnection.sendPreparedStatement("INSERT INTO $tableName VALUES (1)")
+                                }
+                            } as GenericDatabaseException
+                    assertThat(e.errorMessage.message).isEqualTo("duplicate key value violates unique constraint \"${tableName}_pkey\"")
+                }
+            }
+
+            val rows = executeQuery(connection, "SELECT x FROM $tableName ORDER BY x").rows
+            assertThat(rows.length).isEqualTo(0)
+        }
+
+    }
+
+}


### PR DESCRIPTION
`inTransaction` on connection pool was executed on `this` which is the pool itself.
That means each operation was getting another connection.
The fix is to get a concrete connection, and run the transaction on it.

Fixes #177