### PR TITLE
Pool - close the pool after test execution

### DIFF
--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/AbstractAsyncObjectPoolSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/AbstractAsyncObjectPoolSpec.kt
@@ -38,7 +38,7 @@ abstract class AbstractAsyncObjectPoolSpec<T : AsyncObjectPool<Widget>> {
     @After
     fun closePool() {
         if (::pool.isInitialized) {
-            pool.close()
+            pool.close().get()
         }
     }
 

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedAsyncObjectPoolSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedAsyncObjectPoolSpec.kt
@@ -6,12 +6,12 @@ import org.junit.Test
 class ActorBasedAsyncObjectPoolSpec : AbstractAsyncObjectPoolSpec<ActorBasedObjectPool<Widget>>() {
 
 
-    override fun pool(factory: ObjectFactory<Widget>, conf: PoolConfiguration): ActorBasedObjectPool<Widget> =
+    override fun createPool(factory: ObjectFactory<Widget>, conf: PoolConfiguration): ActorBasedObjectPool<Widget> =
         ActorBasedObjectPool(factory, conf, true)
 
     @Test
     fun `SingleThreadedAsyncObjectPool should successfully record a closed state`() {
-        val p = pool()
+        val p = createPool()
         assertThat(p.close().get()).isEqualTo(p)
         assertThat(p.closed).isTrue()
     }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -29,7 +29,7 @@ class ActorBasedObjectPoolTest {
     @After
     fun closePool() {
         if (::tested.isInitialized) {
-            tested.close()
+            tested.close().get()
         }
     }
 

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
+import org.junit.After
 import org.junit.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
@@ -20,10 +21,21 @@ class ActorBasedObjectPoolTest {
         validationInterval = Long.MAX_VALUE, maxIdle = Long.MAX_VALUE,
         maxObjectTtl = null
     )
-    private var tested = ActorBasedObjectPool(factory, configuration, testItemsPeriodically = false)
+    private lateinit var tested: ActorBasedObjectPool<ForTestingMyWidget>
+
+    private fun createDefaultPool() = ActorBasedObjectPool(factory, configuration, testItemsPeriodically = false)
+
+
+    @After
+    fun closePool() {
+        if (::tested.isInitialized) {
+            tested.close()
+        }
+    }
 
     @Test
     fun `check no take operations can be done after pool is close and connection is cleanup`() {
+        tested = createDefaultPool()
         val widget = tested.take().get()
         tested.close().get()
         verifyException(PoolAlreadyTerminatedException::class.java) {
@@ -34,6 +46,7 @@ class ActorBasedObjectPoolTest {
 
     @Test
     fun `basic take operation`() {
+        tested = createDefaultPool()
         val result = tested.take().get()
         assertThat(result).isEqualTo(factory.created[0])
         assertThat(result).isEqualTo(factory.validated[0])
@@ -83,30 +96,35 @@ class ActorBasedObjectPoolTest {
 
     @Test(expected = Exception::class)
     fun `basic take operation when create failed future should fail`() {
+        tested = createDefaultPool()
         factory.failCreation = true
         tested.take().get()
     }
 
     @Test(expected = Exception::class)
     fun `basic take operation when create failed future should fail 2`() {
+        tested = createDefaultPool()
         factory.failCreationFuture = true
         tested.take().get()
     }
 
     @Test(expected = Exception::class)
     fun `basic take operation when validation failed future should fail`() {
+        tested = createDefaultPool()
         factory.failValidation = true
         tested.take().get()
     }
 
     @Test(expected = Exception::class)
     fun `basic take operation when validation failed future should fail 2`() {
+        tested = createDefaultPool()
         factory.failValidationTry = true
         tested.take().get()
     }
 
     @Test
     fun `basic take-return-take operation`() {
+        tested = createDefaultPool()
         val result = tested.take().get()
         tested.giveBack(result).get()
         val result2 = tested.take().get()
@@ -116,6 +134,7 @@ class ActorBasedObjectPoolTest {
 
     @Test
     fun `take2-return2-take first not validated second is ok should be returned`() {
+        tested = createDefaultPool()
         val result = tested.take().get()
         val result2 = tested.take().get()
         tested.giveBack(result).get()
@@ -142,6 +161,7 @@ class ActorBasedObjectPoolTest {
 
     @Test
     fun `basic pool item validation should return to pool after test`() {
+        tested = createDefaultPool()
         val widget = tested.take().get()
         tested.giveBack(widget).get()
         await.untilCallTo { tested.availableItems } matches { it == listOf(widget) }
@@ -154,6 +174,7 @@ class ActorBasedObjectPoolTest {
 
     @Test
     fun `basic pool item validation should not return to pool after failed test`() {
+        tested = createDefaultPool()
         val widget = tested.take().get()
         tested.giveBack(widget).get()
         await.untilCallTo { tested.availableItems } matches { it == listOf(widget) }
@@ -260,7 +281,8 @@ class ActorBasedObjectPoolTest {
                 maxQueueSize = 1
             ), false
         )
-        takeLostItem()
+        // takeLostItem
+        tested.take().get()
         Thread.sleep(1000)
         System.gc()
         await.untilCallTo { tested.usedItemsSize } matches { it == 0 }
@@ -268,10 +290,6 @@ class ActorBasedObjectPoolTest {
         await.untilCallTo { tested.availableItemsSize } matches { it == 0 }
         System.gc() //to show leak in logging
         Thread.sleep(1000)
-    }
-
-    private fun takeLostItem() {
-        tested.take().get()
     }
 
 }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/PartitionedAsyncObjectPoolSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/PartitionedAsyncObjectPoolSpec.kt
@@ -77,7 +77,7 @@ class PartitionedAsyncObjectPoolSpec {
 
     @After
     fun closePool() {
-        tested.close()
+        tested.close().get()
     }
 
     @Test

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/pool/PartitionedAsyncObjectPoolSpec.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/pool/PartitionedAsyncObjectPoolSpec.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
+import org.junit.After
 import org.junit.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
@@ -17,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class PartitionedAsyncObjectPoolSpec {
 
     private val config = PoolConfiguration(100, Long.MAX_VALUE, 100)
-    private val factory = PartitionedAsyncObjectPoolSpec.ForTestingObjectFactory()
+    private val factory = ForTestingObjectFactory()
 
     private var tested = ActorBasedObjectPool<MyPooledObject>(factory, config, testItemsPeriodically = false)
 
@@ -74,6 +75,10 @@ class PartitionedAsyncObjectPoolSpec {
         }
     }
 
+    @After
+    fun closePool() {
+        tested.close()
+    }
 
     @Test
     fun `pool contents - before exceed maxObjects - take one element`() {


### PR DESCRIPTION
This avoids testAvailableItems continue running and clean up resources
gracefully.