### PR TITLE
prevent false leak detection in tests

### DIFF
--- a/resources/detect-leak.sh
+++ b/resources/detect-leak.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-if grep LEAK: $1 | grep ERROR
+if grep LEAK: $1 | grep ERROR | grep -v testcontainers
 then
-  echo "leak found!!!"
-  grep LEAK: $1 | grep ERROR
+  echo "LEAK FOUND!!!"
+  grep LEAK: $1 | grep ERROR | grep -v testcontainers
   exit 1
 else
   echo "no leak found"


### PR DESCRIPTION
testcontainers report leaks in it's shaded netty.
This is not relevant for jasync leaks themselves.