### PR TITLE
add quill to 'who is using it' in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can view the project's change log [here](CHANGELOG.md).
 * [Zeko Data Mapper](https://github.com/darkredz/Zeko-Data-Mapper)
 * [vertx-jooq async module](https://github.com/jklingsporn/vertx-jooq)
 * [ScalikeJDBC Async](https://github.com/scalikejdbc/scalikejdbc-async)
+* [Quill](https://getquill.io/)
 
 Add your name here!
 


### PR DESCRIPTION
Since version 3.5.2, both mysql and postgresql modules were added to Quill: https://github.com/getquill/quill#quill-jasync