### PR TITLE
fix #184 Implement SuspendingConnectionPool

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/SuspendingConnectionPool.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/SuspendingConnectionPool.kt
@@ -1,0 +1,61 @@
+package com.github.jasync.sql.db.pool
+
+import com.github.jasync.sql.db.ConcreteConnection
+import com.github.jasync.sql.db.Connection
+import com.github.jasync.sql.db.QueryResult
+import com.github.jasync.sql.db.SuspendingConnection
+import com.github.jasync.sql.db.asSuspending
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
+
+fun <T : ConcreteConnection> ConnectionPool<T>.asSuspending(): SuspendingConnectionPool<T> =
+    SuspendingConnectionPool(this)
+
+class SuspendingConnectionPool<T : ConcreteConnection>(
+    val connectionPool: ConnectionPool<T>
+) : SuspendingConnection {
+
+    suspend fun <A> use(f: suspend (SuspendingConnection) -> A): A =
+        connectionPool.use { concreteConnection ->
+            CoroutineScope(Job() + connectionPool.configuration.coroutineDispatcher).future {
+                f(concreteConnection.asSuspending)
+            }
+        }.await()
+
+    override suspend fun disconnect(): Connection = connectionPool.disconnect().await()
+
+    override suspend fun connect(): Connection = connectionPool.connect().await()
+
+    override suspend fun sendQuery(query: String): QueryResult = use { suspendingConnection ->
+        suspendingConnection.sendQuery(query)
+    }
+
+    override suspend fun sendPreparedStatement(
+        query: String,
+        values: List<Any?>,
+        release: Boolean
+    ): QueryResult = use { suspendingConnection ->
+        suspendingConnection.sendPreparedStatement(query, values, release)
+    }
+
+    override suspend fun sendPreparedStatement(
+        query: String,
+        values: List<Any?>
+    ): QueryResult = use { suspendingConnection ->
+        suspendingConnection.sendPreparedStatement(query, values)
+    }
+
+    override suspend fun sendPreparedStatement(
+        query: String
+    ): QueryResult = use { suspendingConnection ->
+        suspendingConnection.sendPreparedStatement(query)
+    }
+
+    override suspend fun <A> inTransaction(
+        f: suspend (SuspendingConnection) -> A
+    ): A = use { suspendingConnection ->
+        suspendingConnection.inTransaction(f)
+    }
+}


### PR DESCRIPTION
This is a draft version of `SuspendingConnectionPool` which is more in line with `SuspendingConnection` implementation (compared to what I originally suggested in #184). If you like the idea I'll add some tests / write some java docs.

BTW I'm not entirely sure I like the idea of creating another coroutine scope for the sake of being able to delegate to the underlying `ConnectionPool.use` implementation. Since `use` is a suspending function it will already have a coroutine scope it can run everything in, including callback. But then again, it might be safe to create another coroutineScope to make sure that uncaught errors aren't propagated to the CoroutineExceptionHandler of the scope the function will be called in...