### PR TITLE
Allow connections in a pool to be initialized with a user-provided SQL query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ project/target/*
 project/project/*
 postgresql-async/target/*
 db-async-common/target/*
+pool-async/target/*
 db-async-common/out/*
 mysql-async/out/*
 postgresql-async/out/*

--- a/db-async-common/src/main/java/com/github/jasync/sql/db/pool/InitializingConnectionFactory.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/pool/InitializingConnectionFactory.kt
@@ -1,0 +1,24 @@
+package com.github.jasync.sql.db.pool
+
+import com.github.jasync.sql.db.ConcreteConnection
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/** A wrapper around [delegate] that runs [initQuery] on every connection when it is created. */
+class InitializingConnectionFactory<T : ConcreteConnection>(
+    private val initQuery: String,
+    private val executionContext: Executor,
+    private val delegate: ConnectionFactory<T>
+) : ConnectionFactory<T>() {
+
+    override fun create(): CompletableFuture<out T> {
+        return delegate.create().thenComposeAsync({ conn ->
+            logger.debug { "Initializing new connection with the configured connectionInitializationQuery" }
+            conn.sendQuery(initQuery)
+                .thenApply { conn }
+        }, executionContext)
+    }
+}

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionPoolConfigurationSpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionPoolConfigurationSpec.kt
@@ -2,6 +2,7 @@ package com.github.jasync.sql.db.mysql
 
 import com.github.jasync.sql.db.Connection
 import com.github.jasync.sql.db.ConnectionPoolConfiguration
+import com.github.jasync.sql.db.ConnectionPoolConfigurationBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -38,14 +39,29 @@ class ConnectionPoolConfigurationSpec : ConnectionHelper() {
         }
     }
 
-    private fun <T> withPoolConfigurationConnectionBuilderConnection(fn: (Connection) -> T): T {
-        val connection = MySQLConnectionBuilder.createConnectionPool {
-            host = ContainerHelper.defaultConfiguration.host
-            port = ContainerHelper.defaultConfiguration.port
-            database = ContainerHelper.defaultConfiguration.database
-            username = ContainerHelper.defaultConfiguration.username
-            password = ContainerHelper.defaultConfiguration.password
+    @Test
+    fun `configured connection pool should respect the init query`() {
+        withPoolConfigurationConnectionBuilderConnection(
+            { connectionInitializationQuery = "SET @v1 = 123" }
+        ) { handler ->
+            assertThat(executeQuery(handler, "SELECT @v1").rows[0].getLong(0)).isEqualTo(123L)
         }
+    }
+
+    private fun <T> withPoolConfigurationConnectionBuilderConnection(
+        builder: ConnectionPoolConfigurationBuilder.() -> Unit = {},
+        fn: (Connection) -> T
+    ): T {
+        val connection = MySQLConnectionBuilder.createConnectionPool(
+            ConnectionPoolConfigurationBuilder(
+                host = ContainerHelper.defaultConfiguration.host,
+                port = ContainerHelper.defaultConfiguration.port,
+                database = ContainerHelper.defaultConfiguration.database,
+                username = ContainerHelper.defaultConfiguration.username,
+                password = ContainerHelper.defaultConfiguration.password
+            ).apply(builder)
+        )
+
         try {
             return fn(connection)
         } finally {


### PR DESCRIPTION
Add connectionInitializationQuery as a new parameter to ConnectionPoolConfiguration. The new parameter enables users to provide an SQL query that will be invoked on all connections created for the pool. This can be useful for ensuring state tied to the connection lifecycle is properly configured, such as search_path for PostgreSQL.

The motivation for this change is closely related to this previous request from an unrelated user: https://gitter.im/jasync-sql/support?at=6039e0d0e562cf54ac87aa57