### PR TITLE
add mysql CLIENT_FOUND_ROWS support

### DIFF
--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
@@ -61,6 +61,7 @@ class MySQLConnection @JvmOverloads constructor(
         @Suppress("unused")
         val MicrosecondsVersion = Version(5, 6, 0)
         private val regexForCallInQueryStart = Regex("\\s*call\\s+.*", RegexOption.IGNORE_CASE)
+        const val CLIENT_FOUND_ROWS_PROP_NAME = "jasync.mysql.CLIENT_FOUND_ROWS"
     }
 
     init {
@@ -262,7 +263,7 @@ class MySQLConnection @JvmOverloads constructor(
             }
         }
 
-        val clientFoundRows = System.getProperty("jasync.mysql.CLIENT_FOUND_ROWS") != null
+        val clientFoundRows = System.getProperty(CLIENT_FOUND_ROWS_PROP_NAME) != null
         if (clientFoundRows) {
             logger.debug { "CLIENT_FOUND_ROWS capability set" }
         }

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
@@ -15,8 +15,8 @@ import com.github.jasync.sql.db.mysql.codec.MySQLConnectionHandler
 import com.github.jasync.sql.db.mysql.codec.MySQLHandlerDelegate
 import com.github.jasync.sql.db.mysql.exceptions.MySQLException
 import com.github.jasync.sql.db.mysql.message.client.AuthenticationSwitchResponse
-import com.github.jasync.sql.db.mysql.message.client.HandshakeResponseMessage
 import com.github.jasync.sql.db.mysql.message.client.CapabilityRequestMessage
+import com.github.jasync.sql.db.mysql.message.client.HandshakeResponseMessage
 import com.github.jasync.sql.db.mysql.message.server.AuthenticationSwitchRequest
 import com.github.jasync.sql.db.mysql.message.server.EOFMessage
 import com.github.jasync.sql.db.mysql.message.server.ErrorMessage
@@ -276,7 +276,7 @@ class MySQLConnection @JvmOverloads constructor(
                 CapabilityFlag.CLIENT_SECURE_CONNECTION,
                 CapabilityFlag.CLIENT_SSL.takeIf { switchToSsl },
                 CapabilityFlag.CLIENT_CONNECT_WITH_DB.takeIf { configuration.database != null },
-                CapabilityFlag.CLIENT_CONNECT_ATTRS.takeIf { configuration.applicationName != null },
+                CapabilityFlag.CLIENT_CONNECT_ATTRS.takeIf { configuration.applicationName != null }
         ))
 
         val handshakeResponse = HandshakeResponseMessage(

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/codec/MySQLConnectionHandler.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/codec/MySQLConnectionHandler.kt
@@ -5,13 +5,13 @@ import com.github.jasync.sql.db.exceptions.DatabaseException
 import com.github.jasync.sql.db.general.MutableResultSet
 import com.github.jasync.sql.db.mysql.binary.BinaryRowDecoder
 import com.github.jasync.sql.db.mysql.message.client.AuthenticationSwitchResponse
+import com.github.jasync.sql.db.mysql.message.client.CapabilityRequestMessage
 import com.github.jasync.sql.db.mysql.message.client.CloseStatementMessage
 import com.github.jasync.sql.db.mysql.message.client.HandshakeResponseMessage
 import com.github.jasync.sql.db.mysql.message.client.PreparedStatementExecuteMessage
 import com.github.jasync.sql.db.mysql.message.client.PreparedStatementPrepareMessage
 import com.github.jasync.sql.db.mysql.message.client.QueryMessage
 import com.github.jasync.sql.db.mysql.message.client.QuitMessage
-import com.github.jasync.sql.db.mysql.message.client.CapabilityRequestMessage
 import com.github.jasync.sql.db.mysql.message.client.SendLongDataMessage
 import com.github.jasync.sql.db.mysql.message.server.AuthenticationSwitchRequest
 import com.github.jasync.sql.db.mysql.message.server.BinaryRowMessage

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/codec/MySQLConnectionHandler.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/codec/MySQLConnectionHandler.kt
@@ -11,7 +11,7 @@ import com.github.jasync.sql.db.mysql.message.client.PreparedStatementExecuteMes
 import com.github.jasync.sql.db.mysql.message.client.PreparedStatementPrepareMessage
 import com.github.jasync.sql.db.mysql.message.client.QueryMessage
 import com.github.jasync.sql.db.mysql.message.client.QuitMessage
-import com.github.jasync.sql.db.mysql.message.client.SSLRequestMessage
+import com.github.jasync.sql.db.mysql.message.client.CapabilityRequestMessage
 import com.github.jasync.sql.db.mysql.message.client.SendLongDataMessage
 import com.github.jasync.sql.db.mysql.message.server.AuthenticationSwitchRequest
 import com.github.jasync.sql.db.mysql.message.server.BinaryRowMessage
@@ -273,7 +273,7 @@ class MySQLConnectionHandler(
         }
     }
 
-    fun write(message: SSLRequestMessage): ChannelFuture = writeAndHandleError(message)
+    fun write(message: CapabilityRequestMessage): ChannelFuture = writeAndHandleError(message)
 
     fun write(message: HandshakeResponseMessage): ChannelFuture {
         decoder.hasDoneHandshake = true

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/encoder/SSLRequestEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/encoder/SSLRequestEncoder.kt
@@ -1,7 +1,7 @@
 package com.github.jasync.sql.db.mysql.encoder
 
 import com.github.jasync.sql.db.mysql.message.client.ClientMessage
-import com.github.jasync.sql.db.mysql.message.client.SSLRequestMessage
+import com.github.jasync.sql.db.mysql.message.client.CapabilityRequestMessage
 import com.github.jasync.sql.db.mysql.util.CharsetMapper
 import com.github.jasync.sql.db.util.ByteBufferUtils
 import io.netty.buffer.ByteBuf
@@ -15,7 +15,7 @@ class SSLRequestEncoder(private val charset: Charset, private val charsetMapper:
     }
 
     override fun encode(message: ClientMessage): ByteBuf {
-        require(message is SSLRequestMessage)
+        require(message is CapabilityRequestMessage)
         var clientCapabilities = 0
 
         for (flag in message.flags) {

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/encoder/SSLRequestEncoder.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/encoder/SSLRequestEncoder.kt
@@ -1,7 +1,7 @@
 package com.github.jasync.sql.db.mysql.encoder
 
-import com.github.jasync.sql.db.mysql.message.client.ClientMessage
 import com.github.jasync.sql.db.mysql.message.client.CapabilityRequestMessage
+import com.github.jasync.sql.db.mysql.message.client.ClientMessage
 import com.github.jasync.sql.db.mysql.util.CharsetMapper
 import com.github.jasync.sql.db.util.ByteBufferUtils
 import io.netty.buffer.ByteBuf

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/message/client/CapabilityRequestMessage.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/message/client/CapabilityRequestMessage.kt
@@ -2,4 +2,4 @@ package com.github.jasync.sql.db.mysql.message.client
 
 import com.github.jasync.sql.db.mysql.util.CapabilityFlag
 
-data class SSLRequestMessage(val flags: Set<CapabilityFlag>) : ClientMessage(SslRequest)
+data class CapabilityRequestMessage(val flags: Set<CapabilityFlag>) : ClientMessage(SslRequest)

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/message/client/HandshakeResponseMessage.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/message/client/HandshakeResponseMessage.kt
@@ -3,7 +3,7 @@ package com.github.jasync.sql.db.mysql.message.client
 import java.nio.charset.Charset
 
 data class HandshakeResponseMessage(
-    val header: SSLRequestMessage,
+    val header: CapabilityRequestMessage,
     val username: String,
     val charset: Charset,
     @Suppress("ArrayInDataClass")

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/util/CapabilityFlag.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/util/CapabilityFlag.kt
@@ -3,6 +3,7 @@
 package com.github.jasync.sql.db.mysql.util
 
 enum class CapabilityFlag(val value: Int) {
+    CLIENT_FOUND_ROWS(0x00000002),
     CLIENT_PROTOCOL_41(0x0200),
     CLIENT_CONNECT_WITH_DB(0x0008),
     CLIENT_TRANSACTIONS(0x2000),

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/UpdateQuerySpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/UpdateQuerySpec.kt
@@ -1,0 +1,34 @@
+package com.github.jasync.sql.db.mysql
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class UpdateQuerySpec : ConnectionHelper() {
+
+    @Test
+    fun `test rowsAffected on update with CLIENT_FOUND_ROWS capability should return all filtered rows and not just actual change`() {
+        val tableName = "users_${System.currentTimeMillis()}"
+        System.getProperties().remove(MySQLConnection.CLIENT_FOUND_ROWS_PROP_NAME)
+        try {
+            val createTable = """CREATE TABLE $tableName (
+                              id INT NOT NULL AUTO_INCREMENT ,
+                              name VARCHAR(255) CHARACTER SET 'utf8mb4' NOT NULL ,
+                              PRIMARY KEY (id) );"""
+            val insert = """INSERT INTO $tableName (name) VALUES ('Boogie Man')"""
+            val query = "update $tableName set name = 'Boogie Man' where name = 'Boogie Man'"
+            withConnection { connection ->
+                assertThat(executeQuery(connection, createTable).rowsAffected).isEqualTo(0)
+                assertThat(executeQuery(connection, insert).rowsAffected).isEqualTo(1)
+                val result = executeQuery(connection, query)
+                assertThat(result.rowsAffected).isEqualTo(0L)
+            }
+            System.setProperty(MySQLConnection.CLIENT_FOUND_ROWS_PROP_NAME, "true")
+            withConnection { connection ->
+                val resultWithProp = executeQuery(connection, query)
+                assertThat(resultWithProp.rowsAffected).isEqualTo(1L)
+            }
+        } finally {
+            System.getProperties().remove(MySQLConnection.CLIENT_FOUND_ROWS_PROP_NAME)
+        }
+    }
+}


### PR DESCRIPTION
This commit adds system property jasync.mysql.CLIENT_FOUND_ROWS that
when set will create connections with the flag on.

CLIENT_FOUND_ROWS tells the mysql server to send back all rows in where
clause and not just the ones that were actually updated. See details in:
https://dev.mysql.com/doc/refman/8.0/en/information-functions.html
https://dev.mysql.com/doc/internals/en/capability-flags.html

This makes more sense in some scenarios. For example:
https://github.com/spring-projects/spring-data-r2dbc/issues/253

Also renamed SSLRequestMessage to CapabilityRequestMessage to better
reflect the data.