### PR TITLE
Add minObjects/minActiveConnections support (#267)

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/ConnectionPoolConfiguration.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/ConnectionPoolConfiguration.kt
@@ -72,7 +72,8 @@ data class ConnectionPoolConfiguration @JvmOverloads constructor(
     val allocator: ByteBufAllocator = PooledByteBufAllocator.DEFAULT,
     val applicationName: String? = null,
     val interceptors: List<Supplier<QueryInterceptor>> = emptyList(),
-    val maxConnectionTtl: Long? = null
+    val maxConnectionTtl: Long? = null,
+    val minActiveConnections: Int? = null
 
 ) {
     init {
@@ -86,6 +87,7 @@ data class ConnectionPoolConfiguration @JvmOverloads constructor(
         require(connectionTestTimeout >= 0) { "connectionTestTimeout should not be negative: $connectionTestTimeout" }
         queryTimeout?.let { require(it >= 0) { "queryTimeout should not be negative: $it" } }
         maxConnectionTtl?.let { require(it >= 0) { "queryTimeout should not be negative: $it" } }
+        minActiveConnections?.let { require(minActiveConnections >= 0) { "minActiveConnections should not be negative: $it" } }
     }
 
     val connectionConfiguration = Configuration(
@@ -115,7 +117,8 @@ data class ConnectionPoolConfiguration @JvmOverloads constructor(
         createTimeout = connectionCreateTimeout,
         testTimeout = connectionTestTimeout,
         queryTimeout = queryTimeout,
-        coroutineDispatcher = coroutineDispatcher
+        coroutineDispatcher = coroutineDispatcher,
+        minObjects = minActiveConnections
     )
 
     override fun toString() = """ConnectionPoolConfiguration(host=$host, port=REDACTED, 
@@ -132,7 +135,9 @@ data class ConnectionPoolConfiguration @JvmOverloads constructor(
 |maximumMessageSize=$maximumMessageSize, 
 |allocator=$allocator, 
 |applicationName=$applicationName, 
-|interceptors=$interceptors, maxConnectionTtl=$maxConnectionTtl)""".trimMargin()
+|interceptors=$interceptors, 
+|maxConnectionTtl=$maxConnectionTtl,
+|minActiveConnections=$minActiveConnections)""".trimMargin()
 }
 
 /**
@@ -162,7 +167,8 @@ data class ConnectionPoolConfigurationBuilder @JvmOverloads constructor(
     var allocator: ByteBufAllocator = PooledByteBufAllocator.DEFAULT,
     var applicationName: String? = null,
     var interceptors: MutableList<Supplier<QueryInterceptor>> = mutableListOf<Supplier<QueryInterceptor>>(),
-    var maxConnectionTtl: Long? = null
+    var maxConnectionTtl: Long? = null,
+    var minActiveConnections: Int? = null
 ) {
     fun build(): ConnectionPoolConfiguration = ConnectionPoolConfiguration(
         host = host,
@@ -185,6 +191,7 @@ data class ConnectionPoolConfigurationBuilder @JvmOverloads constructor(
         maximumMessageSize = maximumMessageSize,
         allocator = allocator,
         applicationName = applicationName,
-        interceptors = interceptors
+        interceptors = interceptors,
+        minActiveConnections = minActiveConnections
     )
 }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/ConnectionPoolConfigurationTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/ConnectionPoolConfigurationTest.kt
@@ -2,6 +2,7 @@ package com.github.jasync.sql.db
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import kotlin.test.expect
 
 class ConnectionPoolConfigurationTest {
 
@@ -29,7 +30,8 @@ class ConnectionPoolConfigurationTest {
             queryTimeout = 16,
             maximumMessageSize = 17,
             applicationName = "applicationName",
-            maxConnectionTtl = 18
+            maxConnectionTtl = 18,
+            minActiveConnections = 5
         ).build()
         assertThat(configuration.host).isEqualTo("host")
         assertThat(configuration.connectionConfiguration.host).isEqualTo("host")
@@ -52,6 +54,7 @@ class ConnectionPoolConfigurationTest {
         assertThat(configuration.connectionTestTimeout).isEqualTo(15)
         assertThat(configuration.poolConfiguration.testTimeout).isEqualTo(15)
         assertThat(configuration.poolConfiguration.queryTimeout).isEqualTo(16)
+        assertThat(configuration.minActiveConnections).isEqualTo(5)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -107,6 +110,13 @@ class ConnectionPoolConfigurationTest {
     fun `test error connectionTestTimeout`() {
         ConnectionPoolConfigurationBuilder(
             queryTimeout = -1
+        ).build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test error minActiveConnections`() {
+        ConnectionPoolConfigurationBuilder(
+            minActiveConnections = -1
         ).build()
     }
 }

--- a/db-async-common/src/test/java/com/github/jasync/sql/db/ConnectionPoolConfigurationTest.kt
+++ b/db-async-common/src/test/java/com/github/jasync/sql/db/ConnectionPoolConfigurationTest.kt
@@ -2,7 +2,6 @@ package com.github.jasync.sql.db
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import kotlin.test.expect
 
 class ConnectionPoolConfigurationTest {
 

--- a/pool-async/src/main/java/com/github/jasync/sql/db/pool/ActorBasedObjectPool.kt
+++ b/pool-async/src/main/java/com/github/jasync/sql/db/pool/ActorBasedObjectPool.kt
@@ -257,6 +257,14 @@ private class ObjectPoolActor<T : PooledObject>(
             createObject(null)
             logger.trace { "scheduleNewItemsIfNeeded - creating new object ; $poolStatusString" }
         }
+
+        while (configuration.minObjects != null &&
+            (availableItems.size + inCreateItems.size) < configuration.minObjects &&
+            totalItems < configuration.maxObjects
+        ) {
+            createObject(null)
+            logger.trace { "scheduleNewItemsIfNeeded - creating new object to meet minObjects=${configuration.minObjects} ; $poolStatusString" }
+        }
     }
 
     private val poolStatusString: String

--- a/pool-async/src/main/java/com/github/jasync/sql/db/pool/PoolConfiguration.kt
+++ b/pool-async/src/main/java/com/github/jasync/sql/db/pool/PoolConfiguration.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
  * @param testTimeout the timeout for connection tests performed by pools
  * @param queryTimeout the optional query timeout
  * @param coroutineDispatcher thread pool for the actor operations of the connection pool
+ * @param minObjects the minimum number of objects this pool should hold
  */
 
 data class PoolConfiguration @JvmOverloads constructor(
@@ -28,7 +29,8 @@ data class PoolConfiguration @JvmOverloads constructor(
     val testTimeout: Long = 5000,
     val queryTimeout: Long? = null,
     val coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    val maxObjectTtl: Long? = null
+    val maxObjectTtl: Long? = null,
+    val minObjects: Int? = null
 ) {
     companion object {
         @Suppress("unused")

--- a/pool-async/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
+++ b/pool-async/src/test/java/com/github/jasync/sql/db/pool/ActorBasedObjectPoolTest.kt
@@ -313,6 +313,52 @@ class ActorBasedObjectPoolTest {
         System.gc() // to show leak in logging
         Thread.sleep(1000)
     }
+
+    @Test
+    fun `test minObjects - we maintain a minimum number of objects`() {
+        tested = ActorBasedObjectPool(
+            factory,
+            configuration.copy(minObjects = 3),
+            false
+        )
+        tested.take().get()
+        Thread.sleep(20)
+        assertThat(tested.availableItemsSize).isEqualTo(3)
+    }
+
+    @Test
+    fun `test minObjects - when min = max, we don't go over the total number when returning back`() {
+        tested = ActorBasedObjectPool(
+            factory,
+            configuration.copy(maxObjects = 3, minObjects = 3),
+            false
+        )
+        val widget = tested.take().get()
+        Thread.sleep(20)
+        // 3 max, one active, meaning expecting 2 available
+        assertThat(tested.availableItemsSize).isEqualTo(2)
+        tested.giveBack(widget).get()
+        Thread.sleep(20)
+        assertThat(tested.availableItemsSize).isEqualTo(3)
+    }
+
+    @Test
+    fun `test minObjects - cleaned up objects result in more objects being created`() {
+        tested = ActorBasedObjectPool(
+            factory,
+            configuration.copy(maxObjects = 3, minObjects = 3, maxObjectTtl = 50),
+            false
+        )
+        val widget = tested.take().get()
+        tested.giveBack(widget).get()
+        Thread.sleep(20)
+        assertThat(tested.availableItemsSize).isEqualTo(3)
+        assertThat(factory.created.size).isEqualTo(3)
+        Thread.sleep(70)
+        tested.testAvailableItems()
+        await.untilCallTo { tested.availableItemsSize } matches { it == 3 }
+        await.untilCallTo { factory.created.size } matches { it == 6 }
+    }
 }
 
 private var widgetId = 0


### PR DESCRIPTION
Allows ability to maintain a series of objects in the pool when idle. Motivation here is so that a series of idle connections are maintained, avoiding additional wait time for instances when a new connection has to be established (such as when existing connections are being utilised, or when connections have been cleaned up due to a period of inactivity with an appropriate maxIdleTime set).