### PR TITLE
fix flaky test - close the connection only if there is no errors

### DIFF
--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionHelper.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/ConnectionHelper.kt
@@ -143,13 +143,10 @@ open class ConnectionHelper : ContainerHelper() {
 
     fun <T> withConfigurableConnection(configuration: Configuration, fn: (MySQLConnection) -> T): T {
         val connection = MySQLConnection(configuration)
-
-        try {
-            awaitFuture(connection.connect())
-            return fn(connection)
-        } finally {
-            awaitFuture(connection.close())
-        }
+        awaitFuture(connection.connect())
+        val res = fn(connection)
+        awaitFuture(connection.close())
+        return res
     }
 
     fun <T> withConfigurableOpenConnection(configuration: Configuration, fn: (MySQLConnection) -> T): T {


### PR DESCRIPTION
In some errors closing the connection is throwing another error
to the test so the part we validate which connection is thrown
is failing. The solution is to close the connection only
if there wasn't a failure as part of the normal flow and not
in finally block.

fix #280