### PR TITLE
Add CredentialsProvider interface to allow the use of time based credentials

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/CredentialsProvider.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/CredentialsProvider.kt
@@ -1,0 +1,31 @@
+package com.github.jasync.sql.db
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+/**
+ * A CredentialsProvider that can be used to provide the connection configuration
+ * with on demand credentials on connect.
+ * It can be used to implement time based credential authentication,
+ * eg. IAM based authentication for AWS RDS or Hashicorp Vault database secrets.
+ */
+interface CredentialsProvider {
+    fun provide(): CompletionStage<Credentials>
+}
+
+data class Credentials(val username: String, val password: String?) {
+    override fun toString(): String = "Credentials (username: $username, password: *****)"
+}
+
+/**
+ * A StaticCredentialsProvider implements the CredentialsProvider interface with
+ * a static username / password combination.
+ * It exists mainly to provide a simplified interface for static credentials configuration
+ * that can be set on the connection configuration directly.
+ * It is rarely necessary to use this class directly outside of the driver code base.
+ */
+class StaticCredentialsProvider(val username: String, val password: String?) : CredentialsProvider {
+
+    override fun provide(): CompletionStage<Credentials> =
+        CompletableFuture.completedFuture(Credentials(username, password))
+}

--- a/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnectionBuilder.kt
+++ b/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnectionBuilder.kt
@@ -28,10 +28,7 @@ object PostgreSQLConnectionBuilder {
 
     @JvmStatic
     @JvmOverloads
-    fun createConnectionPool(
-        url: String,
-        configurator: ConnectionPoolConfigurationBuilder.() -> Unit = { }
-    ): ConnectionPool<PostgreSQLConnection> {
+    fun createConnectionPool(url: String, configurator: ConnectionPoolConfigurationBuilder.() -> Unit = { }): ConnectionPool<PostgreSQLConnection> {
         val configuration = URLParser.parseOrDie(url)
         with(configuration) {
             val builder =


### PR DESCRIPTION
It's become increasingly popular for infrastructure providers and security engineers to push for the use of time base credentials for connecting to the database instead of having long lasting secrets hard coded in the database.
 Examples include, among others, [AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) or [HashiCorp VAULT](https://developer.hashicorp.com/vault/docs/secrets/databases/postgresql).

The connection flow is usually like this: When a database driver needs to establish a connection, it will fetch fresh credentials on demand. These credentials are valid for a short time frame, usually minutes, which is long enough for the driver to establish a connection. If the driver ever needs to re-connect, it needs to obtain a fresh set of credentials.
Since most database drivers provide thread pools for handling bare connections, the challenge now lies with making the thread pool aware of the fact that fresh credentials are required and how to obtain them.

This PR extends the `ConnectionPoolConfiguration` with the possibility to provide a `CredentialsProvider` that can be implemented by the user to pass in a custom source for credentials. The `ConnectionFactory` then resolves a fresh configuration every time it establishes a new connection.
I tried to extend all interfaces in a way that should preserve compatibility in nearly all cases.

The `ktLint` task seems to be broken or not setup properly, and running `ktlint -F` on the code base produces a lot of changes all over. I therefore decided to forgo automatic formatting. Hope this is OK.