### PR TITLE
r2dbc-mysql queueing execution of queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ For docs and info see the [wiki](https://github.com/jasync-sql/jasync-sql/wiki).
   <artifactId>jasync-mysql</artifactId>
   <version>2.1.7</version>
 </dependency>
+
 <!-- postgresql -->
 <dependency>
-  <groupId>com.github.jasync-sql</groupId>
-  <artifactId>jasync-postgresql</artifactId>
-  <version>2.1.7</version>
+    <groupId>com.github.jasync-sql</groupId>
+    <artifactId>jasync-postgresql</artifactId>
+    <version>2.1.7</version>
+</dependency>
+
+<!-- r2dbc-mysql -->
+<dependency>
+    <groupId>com.github.jasync-sql</groupId>
+    <artifactId>jasync-r2dbc-mysql</artifactId>
+    <version>2.1.7</version>
 </dependency>
 ```
 

--- a/r2dbc-mysql/build.gradle.kts
+++ b/r2dbc-mysql/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     compile("io.netty:netty-transport:$NETTY_VERSION")
     compile("io.netty:netty-handler:$NETTY_VERSION")
     compile("io.github.microutils:kotlin-logging:$KOTLIN_LOGGING_VERSION")
+    implementation("org.springframework.data:spring-data-r2dbc:1.5.6")
     testImplementation("junit:junit:$JUNIT_VERSION")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$KOTLIN_VERSION")
     testImplementation("org.assertj:assertj-core:$ASSERTJ_VERSION")

--- a/r2dbc-mysql/build.gradle.kts
+++ b/r2dbc-mysql/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     compile("io.netty:netty-transport:$NETTY_VERSION")
     compile("io.netty:netty-handler:$NETTY_VERSION")
     compile("io.github.microutils:kotlin-logging:$KOTLIN_LOGGING_VERSION")
-    implementation("org.springframework.data:spring-data-r2dbc:1.5.6")
+    testImplementation("org.springframework.data:spring-data-r2dbc:1.5.6")
     testImplementation("junit:junit:$JUNIT_VERSION")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$KOTLIN_VERSION")
     testImplementation("org.assertj:assertj-core:$ASSERTJ_VERSION")

--- a/r2dbc-mysql/src/main/java/DbExecutionTask.kt
+++ b/r2dbc-mysql/src/main/java/DbExecutionTask.kt
@@ -1,0 +1,7 @@
+import com.github.jasync.sql.db.QueryResult
+import reactor.core.publisher.MonoSink
+
+data class DbExecutionTask(
+    val sink: MonoSink<QueryResult>,
+    val sql: String
+)

--- a/r2dbc-mysql/src/main/java/DbExecutionTask.kt
+++ b/r2dbc-mysql/src/main/java/DbExecutionTask.kt
@@ -1,7 +1,25 @@
 import com.github.jasync.sql.db.QueryResult
+import com.github.jasync.sql.db.interceptor.PreparedStatementParams
 import reactor.core.publisher.MonoSink
 
-data class DbExecutionTask(
-    val sink: MonoSink<QueryResult>,
+interface DbExecutionTask {
+    val sink: MonoSink<QueryResult>
+}
+
+data class QueryExecutionTask(
+    override val sink: MonoSink<QueryResult>,
     val sql: String
-)
+) : DbExecutionTask {
+    override fun toString(): String {
+        return this.sql
+    }
+}
+
+data class PreparedStatementExecutionTask(
+    override val sink: MonoSink<QueryResult>,
+    val preparedStatementParams: PreparedStatementParams
+) : DbExecutionTask {
+    override fun toString(): String {
+        return this.preparedStatementParams.toString()
+    }
+}

--- a/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
+++ b/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
@@ -34,7 +34,7 @@ class JasyncClientConnection(
         QueueingExecutionJasyncConnectionAdapter(jasyncConnection, queueingQueryExecutor)
 
     init {
-        Executors.newCachedThreadPool().submit(queueingQueryExecutor)
+        Executors.newSingleThreadExecutor().submit(queueingQueryExecutor)
     }
 
     override fun validate(depth: ValidationDepth): Publisher<Boolean> {

--- a/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
+++ b/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
@@ -8,8 +8,13 @@ import com.github.jasync.sql.db.mysql.MySQLConnection
 import com.github.jasync.sql.db.mysql.pool.MySQLConnectionFactory
 import com.github.jasync.sql.db.util.flatMap
 import com.github.jasync.sql.db.util.map
-import io.r2dbc.spi.*
+import io.r2dbc.spi.Batch
 import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionMetadata
+import io.r2dbc.spi.IsolationLevel
+import io.r2dbc.spi.Statement
+import io.r2dbc.spi.TransactionDefinition
+import io.r2dbc.spi.ValidationDepth
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono

--- a/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
+++ b/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
@@ -30,7 +30,8 @@ class JasyncClientConnection(
 
     private var isolationLevel: IsolationLevel = IsolationLevel.REPEATABLE_READ
     private val queueingQueryExecutor: QueueingQueryExecutor = QueueingQueryExecutor(jasyncConnection)
-    private val queueingExecutionJasyncConnectionAdapter = QueueingExecutionJasyncConnectionAdapter(jasyncConnection, queueingQueryExecutor)
+    private val queueingExecutionJasyncConnectionAdapter =
+        QueueingExecutionJasyncConnectionAdapter(jasyncConnection, queueingQueryExecutor)
 
     init {
         Executors.newCachedThreadPool().submit(queueingQueryExecutor)
@@ -62,7 +63,8 @@ class JasyncClientConnection(
                         .map { this.isolationLevel = isolationLevel; it }
             }
             definition.getAttribute(TransactionDefinition.LOCK_WAIT_TIMEOUT)?.let { timeout ->
-                future = future.flatMap { queueingExecutionJasyncConnectionAdapter.sendQuery("SET innodb_lock_wait_timeout=$timeout") }
+                future =
+                    future.flatMap { queueingExecutionJasyncConnectionAdapter.sendQuery("SET innodb_lock_wait_timeout=$timeout") }
             }
             future = future.flatMap { queueingExecutionJasyncConnectionAdapter.sendQuery("SET AUTOCOMMIT = 0") }
             future.toMono().then()
@@ -122,7 +124,7 @@ class JasyncClientConnection(
     }
 
     override fun close(): Publisher<Void> {
-        return Mono.defer { jasyncConnection.disconnect().toMono().then() }
+        return Mono.defer { queueingExecutionJasyncConnectionAdapter.disconnect().toMono().then() }
     }
 
     override fun createBatch(): Batch {

--- a/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
+++ b/r2dbc-mysql/src/main/java/JasyncClientConnection.kt
@@ -1,20 +1,15 @@
 package com.github.jasync.r2dbc.mysql
 
-import DbExecutionTask
-import QueueingQueryExecutor
+import QueryExecutionTask
 import QueueingExecutionJasyncConnectionAdapter
+import QueueingQueryExecutor
 import com.github.jasync.sql.db.QueryResult
 import com.github.jasync.sql.db.mysql.MySQLConnection
 import com.github.jasync.sql.db.mysql.pool.MySQLConnectionFactory
 import com.github.jasync.sql.db.util.flatMap
 import com.github.jasync.sql.db.util.map
-import io.r2dbc.spi.Batch
+import io.r2dbc.spi.*
 import io.r2dbc.spi.Connection
-import io.r2dbc.spi.ConnectionMetadata
-import io.r2dbc.spi.IsolationLevel
-import io.r2dbc.spi.Statement
-import io.r2dbc.spi.TransactionDefinition
-import io.r2dbc.spi.ValidationDepth
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
@@ -137,7 +132,7 @@ class JasyncClientConnection(
 
     private fun executeVoid(sql: String) =
         Mono.create<QueryResult> {
-            queueingQueryExecutor.enqueue(DbExecutionTask(it, sql))
+            queueingQueryExecutor.enqueue(QueryExecutionTask(it, sql))
         }.then()
 
     private fun assertValidSavepointName(name: String) {

--- a/r2dbc-mysql/src/main/java/JasyncConnectionFactory.kt
+++ b/r2dbc-mysql/src/main/java/JasyncConnectionFactory.kt
@@ -11,7 +11,12 @@ import reactor.kotlin.core.publisher.toMono
 class JasyncConnectionFactory(private val mySQLConnectionFactory: MySQLConnectionFactory) : ConnectionFactory {
 
     override fun create(): Publisher<out Connection> {
-        return Mono.defer { mySQLConnectionFactory.create().toMono().map { JasyncClientConnection(it, mySQLConnectionFactory) } }
+        return Mono.defer { mySQLConnectionFactory.create().toMono().map {
+            JasyncClientConnection(
+                it,
+                mySQLConnectionFactory
+            )
+        } }
     }
 
     override fun getMetadata(): ConnectionFactoryMetadata {

--- a/r2dbc-mysql/src/main/java/JasyncConnectionFactory.kt
+++ b/r2dbc-mysql/src/main/java/JasyncConnectionFactory.kt
@@ -11,12 +11,14 @@ import reactor.kotlin.core.publisher.toMono
 class JasyncConnectionFactory(private val mySQLConnectionFactory: MySQLConnectionFactory) : ConnectionFactory {
 
     override fun create(): Publisher<out Connection> {
-        return Mono.defer { mySQLConnectionFactory.create().toMono().map {
-            JasyncClientConnection(
-                it,
-                mySQLConnectionFactory
-            )
-        } }
+        return Mono.defer {
+            mySQLConnectionFactory.create().toMono().map {
+                JasyncClientConnection(
+                    it,
+                    mySQLConnectionFactory
+                )
+            }
+        }
     }
 
     override fun getMetadata(): ConnectionFactoryMetadata {

--- a/r2dbc-mysql/src/main/java/QueueingExecutionJasyncConnectionAdapter.kt
+++ b/r2dbc-mysql/src/main/java/QueueingExecutionJasyncConnectionAdapter.kt
@@ -1,0 +1,15 @@
+import com.github.jasync.sql.db.Connection
+import com.github.jasync.sql.db.QueryResult
+import reactor.core.publisher.Mono
+import java.util.concurrent.CompletableFuture
+import com.github.jasync.sql.db.Connection as JasyncConnection
+
+class QueueingExecutionJasyncConnectionAdapter(
+    private val delegate: JasyncConnection,
+    private val queueingQueryExecutor: QueueingQueryExecutor
+) : Connection by delegate {
+    override fun sendQuery(query: String): CompletableFuture<QueryResult> {
+        return Mono.create<QueryResult> { queueingQueryExecutor.enqueue(DbExecutionTask(it, query)) }
+            .toFuture()
+    }
+}

--- a/r2dbc-mysql/src/main/java/QueueingExecutionJasyncConnectionAdapter.kt
+++ b/r2dbc-mysql/src/main/java/QueueingExecutionJasyncConnectionAdapter.kt
@@ -1,5 +1,6 @@
 import com.github.jasync.sql.db.Connection
 import com.github.jasync.sql.db.QueryResult
+import com.github.jasync.sql.db.interceptor.PreparedStatementParams
 import reactor.core.publisher.Mono
 import java.util.concurrent.CompletableFuture
 import com.github.jasync.sql.db.Connection as JasyncConnection
@@ -9,12 +10,27 @@ class QueueingExecutionJasyncConnectionAdapter(
     private val queueingQueryExecutor: QueueingQueryExecutor
 ) : Connection by delegate {
     override fun sendQuery(query: String): CompletableFuture<QueryResult> {
-        return Mono.create<QueryResult> { queueingQueryExecutor.enqueue(DbExecutionTask(it, query)) }
+        return Mono.create<QueryResult> { queueingQueryExecutor.enqueue(QueryExecutionTask(it, query)) }
             .toFuture()
     }
 
     override fun disconnect(): CompletableFuture<Connection> {
         queueingQueryExecutor.shutdown()
         return delegate.disconnect()
+    }
+
+    override fun sendPreparedStatement(
+        query: String,
+        values: List<Any?>,
+        release: Boolean
+    ): CompletableFuture<QueryResult> {
+        return Mono.create<QueryResult> {
+            queueingQueryExecutor.enqueue(
+                PreparedStatementExecutionTask(
+                    it,
+                    PreparedStatementParams(query = query, values = values, release = release)
+                )
+            )
+        }.toFuture()
     }
 }

--- a/r2dbc-mysql/src/main/java/QueueingExecutionJasyncConnectionAdapter.kt
+++ b/r2dbc-mysql/src/main/java/QueueingExecutionJasyncConnectionAdapter.kt
@@ -12,4 +12,9 @@ class QueueingExecutionJasyncConnectionAdapter(
         return Mono.create<QueryResult> { queueingQueryExecutor.enqueue(DbExecutionTask(it, query)) }
             .toFuture()
     }
+
+    override fun disconnect(): CompletableFuture<Connection> {
+        queueingQueryExecutor.shutdown()
+        return delegate.disconnect()
+    }
 }

--- a/r2dbc-mysql/src/main/java/QueueingQueryExecutor.kt
+++ b/r2dbc-mysql/src/main/java/QueueingQueryExecutor.kt
@@ -1,0 +1,38 @@
+import com.github.jasync.sql.db.Connection
+import org.slf4j.LoggerFactory
+import java.util.*
+import java.util.concurrent.ArrayBlockingQueue
+
+class QueueingQueryExecutor(
+    private val jasyncConnection: Connection
+) : Runnable {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val dbExecutionTaskQueue: Queue<DbExecutionTask> =
+        ArrayBlockingQueue(256, true)
+
+    fun enqueue(dbExecutionTask: DbExecutionTask) {
+        try {
+            dbExecutionTaskQueue.offer(dbExecutionTask)
+        } catch (e: IllegalStateException) {
+            // queue capacity full
+            logger.error("Failed to enqueue DbExecutionTask $e", e)
+            dbExecutionTask.sink.error(e)
+        }
+    }
+
+    override fun run() {
+        while (true) {
+            if (dbExecutionTaskQueue.isNotEmpty()) {
+                val task = dbExecutionTaskQueue.poll()
+                try {
+                    val result = jasyncConnection.sendQuery(task.sql).join()
+                    task.sink.success(result)
+                } catch (e: Exception) {
+                    logger.error("Exception on sendQuery - $e", e)
+                    task.sink.error(e)
+                }
+            }
+        }
+    }
+}

--- a/r2dbc-mysql/src/main/java/QueueingQueryExecutor.kt
+++ b/r2dbc-mysql/src/main/java/QueueingQueryExecutor.kt
@@ -1,6 +1,6 @@
 import com.github.jasync.sql.db.Connection
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.Queue
 import java.util.concurrent.ArrayBlockingQueue
 
 class QueueingQueryExecutor(

--- a/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/JasyncR2dbcIntegTest.kt
+++ b/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/JasyncR2dbcIntegTest.kt
@@ -85,23 +85,26 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
 
             val tcf = TransactionAwareConnectionFactoryProxy(cf)
 
-            val transactionExecution = to.transactional(Mono.from(tcf.create()
-                .flatMapMany { connection ->
-                    val pub = connection.createStatement("SELECT SLEEP(5)")
-                        .execute()
-                    when (pub) {
-                        is Mono -> pub.doOnSubscribe {
-                            queryExecutionFlag.compareAndSet(false, true)
-                        }
+            val transactionExecution = to.transactional(
+                Mono.from(
+                    tcf.create()
+                        .flatMapMany { connection ->
+                            val pub = connection.createStatement("SELECT SLEEP(5)")
+                                .execute()
+                            when (pub) {
+                                is Mono -> pub.doOnSubscribe {
+                                    queryExecutionFlag.compareAndSet(false, true)
+                                }
 
-                        is Flux -> pub.doOnSubscribe {
-                            queryExecutionFlag.compareAndSet(false, true)
-                        }
+                                is Flux -> pub.doOnSubscribe {
+                                    queryExecutionFlag.compareAndSet(false, true)
+                                }
 
-                        else -> pub
-                    }
-                }
-            )).subscribe()
+                                else -> pub
+                            }
+                        }
+                )
+            ).subscribe()
             await.untilAtomic(queryExecutionFlag, IsEqual(true))
             transactionExecution.dispose()
             Thread.sleep(10000)

--- a/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/JasyncR2dbcIntegTest.kt
+++ b/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/JasyncR2dbcIntegTest.kt
@@ -104,9 +104,7 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
             )).subscribe()
             await.untilAtomic(queryExecutionFlag, IsEqual(true))
             transactionExecution.dispose()
-            await.until {
-                transactionExecution.isDisposed
-            }
+            Thread.sleep(10000)
         }
     }
 }


### PR DESCRIPTION
This is my suggested fix for issue https://github.com/jasync-sql/jasync-sql/issues/255#issuecomment-1336219534.

Since in reactor environment, multiple threads can access to the same connection unintendedly, I added a queue per `JasyncClientConnection`.