### PR TITLE
r2bc-mysql close connection on query conflict

### DIFF
--- a/r2dbc-mysql/build.gradle.kts
+++ b/r2dbc-mysql/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     compile("io.netty:netty-transport:$NETTY_VERSION")
     compile("io.netty:netty-handler:$NETTY_VERSION")
     compile("io.github.microutils:kotlin-logging:$KOTLIN_LOGGING_VERSION")
+    implementation("org.springframework.data:spring-data-r2dbc:1.5.6")
     testImplementation("junit:junit:$JUNIT_VERSION")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$KOTLIN_VERSION")
     testImplementation("org.assertj:assertj-core:$ASSERTJ_VERSION")

--- a/r2dbc-mysql/build.gradle.kts
+++ b/r2dbc-mysql/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     compile("io.netty:netty-transport:$NETTY_VERSION")
     compile("io.netty:netty-handler:$NETTY_VERSION")
     compile("io.github.microutils:kotlin-logging:$KOTLIN_LOGGING_VERSION")
-    implementation("org.springframework.data:spring-data-r2dbc:1.5.6")
+    testImplementation("org.springframework.data:spring-data-r2dbc:1.5.6")
     testImplementation("junit:junit:$JUNIT_VERSION")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$KOTLIN_VERSION")
     testImplementation("org.assertj:assertj-core:$ASSERTJ_VERSION")

--- a/r2dbc-mysql/src/main/java/IgnoreExceptionConditions.kt
+++ b/r2dbc-mysql/src/main/java/IgnoreExceptionConditions.kt
@@ -1,0 +1,7 @@
+package com.github.jasync.r2dbc.mysql
+
+import com.github.jasync.sql.db.exceptions.ConnectionStillRunningQueryException
+
+fun isRollbackQueryConflictException(sql: String, exception: Throwable): Boolean {
+    return sql == "ROLLBACK" && exception is ConnectionStillRunningQueryException
+}


### PR DESCRIPTION
This is an implementation of what @oshai suggested in the following comment:
https://github.com/jasync-sql/jasync-sql/pull/343#issuecomment-1347020196

As @oshai mentioned in the above thread, we may take advantage of an implicit rollback when ROLLBACK query conflict with other running queries.

I prefer this version to the second (https://github.com/jasync-sql/jasync-sql/pull/345) one.
This solution is more simple, stable, and less side effects.

Thank you @oshai for a good idea to start with.