### PR TITLE
Fixed statement timeout not working.

### DIFF
--- a/r2dbc-mysql/src/main/java/MysqlConnectionFactoryProvider.kt
+++ b/r2dbc-mysql/src/main/java/MysqlConnectionFactoryProvider.kt
@@ -10,6 +10,7 @@ import io.r2dbc.spi.ConnectionFactoryOptions.DRIVER
 import io.r2dbc.spi.ConnectionFactoryOptions.HOST
 import io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD
 import io.r2dbc.spi.ConnectionFactoryOptions.PORT
+import io.r2dbc.spi.ConnectionFactoryOptions.STATEMENT_TIMEOUT
 import io.r2dbc.spi.ConnectionFactoryOptions.USER
 import io.r2dbc.spi.ConnectionFactoryProvider
 import io.r2dbc.spi.Option
@@ -28,12 +29,6 @@ class MysqlConnectionFactoryProvider : ConnectionFactoryProvider {
          */
         @JvmField
         val APPLICATION_NAME: Option<String> = Option.valueOf("applicationName")
-
-        /**
-         * Query timeout.
-         */
-        @JvmField
-        val QUERY_TIMEOUT: Option<Duration> = Option.valueOf("queryTimeout")
 
         /**
          * Driver option value.
@@ -74,7 +69,7 @@ class MysqlConnectionFactoryProvider : ConnectionFactoryProvider {
             database = connectionFactoryOptions.getValue(DATABASE) as String?,
             applicationName = connectionFactoryOptions.getValue(APPLICATION_NAME) as String?,
             connectionTimeout = (connectionFactoryOptions.getValue(CONNECT_TIMEOUT) as Duration?)?.toMillis()?.toInt() ?: 5000,
-            queryTimeout = connectionFactoryOptions.getValue(QUERY_TIMEOUT) as Duration?
+            queryTimeout = connectionFactoryOptions.getValue(STATEMENT_TIMEOUT) as Duration?
         )
         return JasyncConnectionFactory(MySQLConnectionFactory(configuration))
     }


### PR DESCRIPTION
This fix relates to one statement timeout issues: https://github.com/jasync-sql/jasync-sql/issues/338
Since `QUERY_TIMEOUT` was not utilised by the r2dbc-spi, hence have replaced it with `STATEMENT_TIMEOUT`. As the underlying implementation for `STATEMENT_TIMEOUT` will remain same as `QUERY_TIMEOUT`, therefore the underlying logic has not been modified. 

Query timeout was initially added in commit: https://github.com/jasync-sql/jasync-sql/commit/686e20f9169cea37c0dbcca0bbbb9e57099a79df