### PR TITLE
Added MySQL Error 1062 mapping to R2dbcDataIntegrityViolationException

### DIFF
--- a/r2dbc-mysql/src/main/java/JasyncStatement.kt
+++ b/r2dbc-mysql/src/main/java/JasyncStatement.kt
@@ -152,6 +152,13 @@ internal class JasyncStatement(private val clientSupplier: Supplier<JasyncConnec
                     throwable
                 )
 
+                errorMessage.errorCode == MysqlErrors.ER_DUP_ENTRY -> R2dbcDataIntegrityViolationException(
+                    errorMessage.errorMessage,
+                    errorMessage.sqlState,
+                    errorMessage.errorCode,
+                    throwable
+                )
+
                 errorMessage.errorCode == MysqlErrors.ER_PARSE_ERROR -> R2dbcBadGrammarException(
                     errorMessage.errorMessage,
                     errorMessage.sqlState,


### PR DESCRIPTION
Fix for issue [Duplicate entry on a table mapped to generic exception](https://github.com/jasync-sql/jasync-sql/issues/375)