### PR TITLE
[r2dbc-mysql] Fix `getColumnMetadatas()` of `JasyncMetadata`

### DIFF
--- a/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/JasyncR2dbcIntegTest.kt
+++ b/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/JasyncR2dbcIntegTest.kt
@@ -10,7 +10,7 @@ import io.r2dbc.spi.Parameter
 import io.r2dbc.spi.Result
 import io.r2dbc.spi.Type
 import mu.KotlinLogging
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.hamcrest.core.IsEqual
 import org.junit.Test
@@ -44,15 +44,15 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
                 .flatMap { result ->
                     result
                         .map { row, rowMetadata ->
-                            Assertions.assertThat(row.get("number_tinyint") as Byte).isEqualTo(-100)
-                            Assertions.assertThat(row.get("number_smallint") as Short).isEqualTo(32766)
-                            Assertions.assertThat(row.get("number_mediumint") as Int).isEqualTo(8388607)
-                            Assertions.assertThat(row.get("number_int") as Int).isEqualTo(2147483647)
-                            Assertions.assertThat(row.get("number_bigint") as Long).isEqualTo(9223372036854775807L)
-                            Assertions.assertThat(row.get("number_decimal")).isEqualTo(BigDecimal("450.764491"))
-                            Assertions.assertThat(row.get("number_float")).isEqualTo(14.7F)
-                            Assertions.assertThat(row.get("number_double")).isEqualTo(87650.9876)
-                            Assertions.assertThat(rowMetadata.columnMetadatas.map { it.name }).isEqualTo(
+                            assertThat(row.get("number_tinyint") as Byte).isEqualTo(-100)
+                            assertThat(row.get("number_smallint") as Short).isEqualTo(32766)
+                            assertThat(row.get("number_mediumint") as Int).isEqualTo(8388607)
+                            assertThat(row.get("number_int") as Int).isEqualTo(2147483647)
+                            assertThat(row.get("number_bigint") as Long).isEqualTo(9223372036854775807L)
+                            assertThat(row.get("number_decimal")).isEqualTo(BigDecimal("450.764491"))
+                            assertThat(row.get("number_float")).isEqualTo(14.7F)
+                            assertThat(row.get("number_double")).isEqualTo(87650.9876)
+                            assertThat(rowMetadata.columnMetadatas.map { it.name }).isEqualTo(
                                 listOf(
                                     "id",
                                     "number_tinyint",
@@ -78,8 +78,8 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
         withConnection { c ->
             var filtering = 0
             var rows = 0
-            executeQuery(c, createTable)
-            executeQuery(c, """INSERT INTO users (name) VALUES ('Boogie Man'),('Dambeldor')""")
+            executeQuery(c, createUserTable)
+            executeQuery(c, insertUsers)
             val cf = createJasyncConnectionFactory(c)
             Mono.from(cf.create())
                 .flatMapMany { connection ->
@@ -109,8 +109,8 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
     fun `bind test`() {
         withConnection { c ->
             var rows = 0
-            executeQuery(c, createTable)
-            executeQuery(c, """INSERT INTO users (name) VALUES ('Boogie Man'),('Dambeldor')""")
+            executeQuery(c, createUserTable)
+            executeQuery(c, insertUsers)
             val cf = createJasyncConnectionFactory(c)
             Mono.from(cf.create())
                 .flatMapMany { connection ->
@@ -139,8 +139,8 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
     fun `bind test for parametrized`() {
         withConnection { c ->
             var rows = 0
-            executeQuery(c, createTable)
-            executeQuery(c, """INSERT INTO users (name) VALUES ('Boogie Man'),('Dambeldor')""")
+            executeQuery(c, createUserTable)
+            executeQuery(c, insertUsers)
             val cf = createJasyncConnectionFactory(c)
             Mono.from(cf.create())
                 .flatMapMany { connection ->
@@ -161,6 +161,41 @@ class JasyncR2dbcIntegTest : R2dbcConnectionHelper() {
                 }
                 .subscribe()
             await.until { rows == 1 }
+        }
+    }
+
+    @Test
+    fun `join tables which have column with the same names test`() {
+        withConnection { c ->
+            var rows = 0
+            executeQuery(c, createUserTable)
+            executeQuery(c, insertUsers)
+            executeQuery(c, createPostTable)
+            executeQuery(c, insertPosts)
+            val cf = createJasyncConnectionFactory(c)
+            Mono.from(cf.create())
+                .flatMapMany { connection ->
+                    connection
+                        .createStatement("SELECT * FROM users JOIN posts ON users.id = posts.user_id")
+                        .execute()
+                }
+                .flatMap { result ->
+                    result
+                        .map { row, rowMetadata ->
+                            assertThat(rowMetadata.columnMetadatas.map { it.name }).isEqualTo(
+                                listOf(
+                                    "id",
+                                    "name",
+                                    "id",
+                                    "title",
+                                    "user_id",
+                                )
+                            )
+                        }
+                }
+                .doOnNext { rows++ }
+                .subscribe()
+            await.until { rows == 2 }
         }
     }
 

--- a/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/R2dbcConnectionHelper.kt
+++ b/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/integ/R2dbcConnectionHelper.kt
@@ -79,15 +79,23 @@ open class R2dbcConnectionHelper : R2dbcContainerHelper() {
       insert into posts (created_at_date, created_at_datetime, created_at_timestamp, created_at_time, created_at_year)
       values ( '2038-01-19', '2013-01-19 03:14:07', '2020-01-19 03:14:07', '03:14:07', '1999' )
     """
-    val createTable = """CREATE TEMPORARY TABLE users (
+
+    val createUserTable = """CREATE TEMPORARY TABLE users (
                               id INT NOT NULL AUTO_INCREMENT ,
                               name VARCHAR(255) CHARACTER SET 'utf8' NOT NULL ,
                               PRIMARY KEY (id) );"""
-    val insert = """INSERT INTO users (name) VALUES ('Boogie Man')"""
-    val select = """SELECT * FROM users"""
+    val insertUsers = """INSERT INTO users (name) VALUES ('Boogie Man'), ('Dambeldor')"""
+    val selectUsers = """SELECT * FROM users"""
+
+    val createPostTable = """CREATE TEMPORARY TABLE posts (
+                              id INT NOT NULL AUTO_INCREMENT ,
+                              title VARCHAR(255) CHARACTER SET 'utf8' NOT NULL ,
+                              user_id INT NOT NULL ,
+                              PRIMARY KEY (id) );"""
+    val insertPosts = """INSERT INTO posts (title, user_id) VALUES ('Hello World', 1), ('Hello World 2', 2)"""
 
     fun getConfiguration(): Configuration {
-        return R2dbcContainerHelper.defaultConfiguration
+        return defaultConfiguration
     }
 
     fun <T> awaitFuture(f: CompletableFuture<T>): T {
@@ -95,7 +103,7 @@ open class R2dbcConnectionHelper : R2dbcContainerHelper() {
     }
 
     fun <T> withPool(f: (ConnectionPool<MySQLConnection>) -> T): T {
-        return withConfigurablePool(R2dbcContainerHelper.defaultConfiguration, f)
+        return withConfigurablePool(defaultConfiguration, f)
     }
 
     fun <T> withConfigurablePool(configuration: Configuration, f: (ConnectionPool<MySQLConnection>) -> T): T {
@@ -127,7 +135,7 @@ open class R2dbcConnectionHelper : R2dbcContainerHelper() {
     }
 
     fun <T> withConnection(fn: (MySQLConnection) -> T): T {
-        return withConfigurableConnection(R2dbcContainerHelper.defaultConfiguration, fn)
+        return withConfigurableConnection(defaultConfiguration, fn)
     }
 
     fun <T> withSSLConnection(


### PR DESCRIPTION
Resolve #390.

Also, I modified the way to build a map of `ColumnMetadata` (using `reversed()`). Because originally [the doc about method implementation (`getColumnMetadata()` and `contains()`)](https://github.com/r2dbc/r2dbc-spi/blob/160cd2743f8ce8551618abcd96fa1d7ee37f8f38/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java#L42) of r2dbc interface `RowMetadata` which says `When a get method contains several columns with same name, then the value of the first matching column will be returned` has been potentially violated (**the last** is used, not **the first**). Although this is meaningless because currently the only implemented method of `ColumnMetadata` is `getName()`.
