### PR TITLE
[r2dbc-mysql] Using MySQL default port when not specified

### DIFF
--- a/r2dbc-mysql/src/main/java/MysqlConnectionFactoryProvider.kt
+++ b/r2dbc-mysql/src/main/java/MysqlConnectionFactoryProvider.kt
@@ -35,6 +35,8 @@ class MysqlConnectionFactoryProvider : ConnectionFactoryProvider {
          */
         const val MYSQL_DRIVER = "mysql"
 
+        const val MYSQL_DEFAULT_PORT = 3306
+
         var CLIENT_FOUND_ROWS: Boolean by ClientFoundRowsDelegate()
 
         init {
@@ -63,7 +65,7 @@ class MysqlConnectionFactoryProvider : ConnectionFactoryProvider {
     override fun create(connectionFactoryOptions: ConnectionFactoryOptions): JasyncConnectionFactory {
         val configuration = Configuration(
             host = connectionFactoryOptions.getValue(HOST) as String? ?: throw IllegalArgumentException("HOST is missing"),
-            port = connectionFactoryOptions.getValue(PORT) as Int? ?: throw IllegalArgumentException("PORT is missing"),
+            port = connectionFactoryOptions.getValue(PORT) as Int? ?: MYSQL_DEFAULT_PORT,
             username = connectionFactoryOptions.getValue(USER) as String? ?: throw IllegalArgumentException("USER is missing"),
             password = connectionFactoryOptions.getValue(PASSWORD)?.toString(),
             database = connectionFactoryOptions.getValue(DATABASE) as String?,
@@ -80,7 +82,6 @@ class MysqlConnectionFactoryProvider : ConnectionFactoryProvider {
         return when {
             driver == null || driver != MYSQL_DRIVER -> false
             !connectionFactoryOptions.hasOption(HOST) -> false
-            !connectionFactoryOptions.hasOption(PORT) -> false
             !connectionFactoryOptions.hasOption(USER) -> false
             else -> true
         }

--- a/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/MysqlConnectionFactoryProviderTest.kt
+++ b/r2dbc-mysql/src/test/java/com/github/jasync/r2dbc/mysql/MysqlConnectionFactoryProviderTest.kt
@@ -11,14 +11,34 @@ class MysqlConnectionFactoryProviderTest {
 
     @Test
     fun shouldCreateMysqlConnectionWithMysqlSSLConfigurationFactory() {
-
-        val options =
-            ConnectionFactoryOptions.parse("r2dbc:mysql://user@host:443/")
+        val options = ConnectionFactoryOptions.parse("r2dbc:mysql://user@host:443/")
 
         // when
         val result = provider.create(options)
 
         // then
         assertEquals(SSLConfiguration(), result.mySQLConnectionFactory.configuration.ssl)
+    }
+
+    @Test
+    fun shouldUseDefaultPortWhenPortIsNotSpecified() {
+        val options = ConnectionFactoryOptions.parse("r2dbc:mysql://user@host/")
+
+        // when
+        val result = provider.create(options)
+
+        // then
+        assertEquals(3306, result.mySQLConnectionFactory.configuration.port)
+    }
+
+    @Test
+    fun shouldUseSpecifiedPort() {
+        val options = ConnectionFactoryOptions.parse("r2dbc:mysql://user@host:3307/")
+
+        // when
+        val result = provider.create(options)
+
+        // then
+        assertEquals(3307, result.mySQLConnectionFactory.configuration.port)
     }
 }


### PR DESCRIPTION
Resolve #393 

Use MySQL default port `3306` when a port to use is not specified.
