### PR TITLE
Add query to InsufficientParametersException

### DIFF
--- a/db-async-common/src/main/java/com/github/jasync/sql/db/exceptions/InsufficientParametersException.kt
+++ b/db-async-common/src/main/java/com/github/jasync/sql/db/exceptions/InsufficientParametersException.kt
@@ -10,10 +10,11 @@ package com.github.jasync.sql.db.exceptions
  * @param given the collection given
  */
 @Suppress("RedundantVisibilityModifier")
-public class InsufficientParametersException(expected: Int, given: List<Any?>) : DatabaseException(
-    "The query contains %s parameters but you gave it %s (%s)".format(
+public class InsufficientParametersException(query: String, expected: Int, given: List<Any?>) : DatabaseException(
+    "The query contains %s parameters but you gave it %s (%s):${System.lineSeparator()}%s".format(
         expected,
         given.size,
-        given.joinToString(",")
+        given.joinToString(","),
+        query
     )
 )

--- a/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
+++ b/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt
@@ -468,7 +468,7 @@ class MySQLConnection @JvmOverloads constructor(
         this.validateIsReadyForQuery()
         val totalParameters = params.query.count { it == '?' }
         if (params.values.length != totalParameters) {
-            throw InsufficientParametersException(totalParameters, params.values)
+            throw InsufficientParametersException(params.query, totalParameters, params.values)
         }
         val promise = CompletableFuture<QueryResult>()
         this.setQueryPromise(promise)

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QuerySpec.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/QuerySpec.kt
@@ -239,10 +239,11 @@ class QuerySpec : ConnectionHelper() {
     @Test
     fun `connection should fail if number of args required is different than the number of provided parameters`() {
         withConnection { connection ->
-            verifyException(InsufficientParametersException::class.java) {
+            val query = "select * from some_table where c = ? and b = ?"
+            verifyException(InsufficientParametersException::class.java, containedInMessage = query) {
                 executePreparedStatement(
                     connection,
-                    "select * from some_table where c = ? and b = ?",
+                    query,
                     listOf("one", "two", "three")
                 )
             }

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/Utils.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/Utils.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions
 fun verifyException(
     exType: Class<out java.lang.Exception>,
     causeType: Class<out java.lang.Exception>? = null,
+    containedInMessage: String? = null,
     body: () -> Unit
 ): Throwable {
     try {
@@ -13,6 +14,9 @@ fun verifyException(
     } catch (e: Exception) {
         // e.printStackTrace()
         Assertions.assertThat(e::class.java).isEqualTo(exType)
+        if (containedInMessage != null) {
+            Assertions.assertThat(e.message).contains(containedInMessage)
+        }
         causeType?.let { Assertions.assertThat(e.cause!!::class.java).isEqualTo(it) }
         return e.cause ?: e
     }

--- a/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/Utils.kt
+++ b/mysql-async/src/test/java/com/github/jasync/sql/db/mysql/Utils.kt
@@ -14,9 +14,7 @@ fun verifyException(
     } catch (e: Exception) {
         // e.printStackTrace()
         Assertions.assertThat(e::class.java).isEqualTo(exType)
-        if (containedInMessage != null) {
-            Assertions.assertThat(e.message).contains(containedInMessage)
-        }
+        containedInMessage?.let { Assertions.assertThat(e.message).contains(it) }
         causeType?.let { Assertions.assertThat(e.cause!!::class.java).isEqualTo(it) }
         return e.cause ?: e
     }

--- a/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnection.kt
+++ b/postgresql-async/src/main/java/com/github/jasync/sql/db/postgresql/PostgreSQLConnection.kt
@@ -190,7 +190,7 @@ class PostgreSQLConnection @JvmOverloads constructor(
 
         if (holder.paramsCount != params.values.length) {
             this.clearQueryPromise()
-            throw InsufficientParametersException(holder.paramsCount, params.values)
+            throw InsufficientParametersException(params.query, holder.paramsCount, params.values)
         }
 
         this.currentPreparedStatement = Optional.of(holder)

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/Utils.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/Utils.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions
 fun verifyException(
     exType: Class<out java.lang.Exception>,
     causeType: Class<out java.lang.Exception>? = null,
+    containedInMessage: String? = null,
     body: () -> Unit
 ): Throwable {
     try {
@@ -12,6 +13,9 @@ fun verifyException(
         throw Exception("Expected exception was not thrown: ${exType.simpleName}->${causeType?.simpleName}")
     } catch (e: Exception) {
         Assertions.assertThat(e::class.java).isEqualTo(exType)
+        if (containedInMessage != null) {
+            Assertions.assertThat(e.message).contains(containedInMessage)
+        }
         causeType?.let { Assertions.assertThat(e.cause!!::class.java).isEqualTo(it) }
         return e.cause ?: e
     }

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/Utils.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/Utils.kt
@@ -13,9 +13,7 @@ fun verifyException(
         throw Exception("Expected exception was not thrown: ${exType.simpleName}->${causeType?.simpleName}")
     } catch (e: Exception) {
         Assertions.assertThat(e::class.java).isEqualTo(exType)
-        if (containedInMessage != null) {
-            Assertions.assertThat(e.message).contains(containedInMessage)
-        }
+        containedInMessage?.let { Assertions.assertThat(e.message).contains(it) }
         causeType?.let { Assertions.assertThat(e.cause!!::class.java).isEqualTo(it) }
         return e.cause ?: e
     }

--- a/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/PreparedStatementSpec.kt
+++ b/postgresql-async/src/test/java/com/github/aysnc/sql/db/integration/PreparedStatementSpec.kt
@@ -77,7 +77,7 @@ class PreparedStatementSpec : DatabaseTestHelper() {
     fun `prepared statements should raise an exception if the parameter count is different from the given parameters count`() {
         withHandler { handler ->
             executeDdl(handler, this.messagesCreate)
-            verifyException(InsufficientParametersException::class.java) {
+            verifyException(InsufficientParametersException::class.java, containedInMessage = this.messagesSelectOne) {
                 executePreparedStatement(handler, this.messagesSelectOne)
             }
         }
@@ -268,9 +268,10 @@ class PreparedStatementSpec : DatabaseTestHelper() {
     fun `prepared statements should fail if prepared statement has more variables than it was given`() {
         withHandler { handler ->
             executeDdl(handler, messagesCreate)
-            verifyException(InsufficientParametersException::class.java) {
+            val query = "SELECT * FROM messages WHERE content = ? AND moment = ?"
+            verifyException(InsufficientParametersException::class.java, containedInMessage = query) {
                 handler.sendPreparedStatement(
-                    "SELECT * FROM messages WHERE content = ? AND moment = ?",
+                    query,
                     listOf("some content")
                 )
             }


### PR DESCRIPTION
This PR adds query to InsufficientParametersException, to include the SQL in the exception message.

This makes it easier to find what code has failed with insufficient parameters by searching for the query  in client codebase.

It can be hard to find the code because the asynchronous nature of the library does not include stacktrace to call site.  